### PR TITLE
Removal of invalidations in storage channel

### DIFF
--- a/refinedstorage2-grid-api/src/test/java/com/refinedmods/refinedstorage2/api/grid/service/GridServiceImplTest.java
+++ b/refinedstorage2-grid-api/src/test/java/com/refinedmods/refinedstorage2/api/grid/service/GridServiceImplTest.java
@@ -2,16 +2,12 @@ package com.refinedmods.refinedstorage2.api.grid.service;
 
 import com.refinedmods.refinedstorage2.api.core.Action;
 import com.refinedmods.refinedstorage2.api.resource.ResourceAmount;
-import com.refinedmods.refinedstorage2.api.resource.list.ResourceListImpl;
 import com.refinedmods.refinedstorage2.api.storage.CappedStorage;
 import com.refinedmods.refinedstorage2.api.storage.Storage;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannel;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannelImpl;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageTracker;
-import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorage;
 import com.refinedmods.refinedstorage2.test.Rs2Test;
-
-import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -30,10 +26,7 @@ class GridServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        storageChannel = new StorageChannelImpl<>(
-                new CompositeStorage<>(Collections.emptyList(), new ResourceListImpl<>()), ResourceListImpl::new,
-                new StorageTracker<>(() -> 0L)
-        );
+        storageChannel = new StorageChannelImpl<>(new StorageTracker<>(() -> 0L));
         sut = new GridServiceImpl<>(storageChannel, () -> "Test source", r -> MAX_COUNT, 1);
     }
 

--- a/refinedstorage2-network-api/src/main/java/com/refinedmods/refinedstorage2/api/network/node/diskdrive/DiskDriveCompositeStorage.java
+++ b/refinedstorage2-network-api/src/main/java/com/refinedmods/refinedstorage2/api/network/node/diskdrive/DiskDriveCompositeStorage.java
@@ -12,14 +12,13 @@ import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorageLis
 import com.refinedmods.refinedstorage2.api.storage.composite.Priority;
 
 import java.util.Collection;
-import java.util.Collections;
 
-public class DiskDriveStorage<T> implements CompositeStorage<T>, Priority {
+public class DiskDriveCompositeStorage<T> implements CompositeStorage<T>, Priority {
     private final CompositeStorage<T> compositeOfDisks;
     private final DiskDriveNetworkNode diskDrive;
     private final Filter filter;
 
-    protected DiskDriveStorage(DiskDriveNetworkNode diskDrive, Filter filter) {
+    protected DiskDriveCompositeStorage(DiskDriveNetworkNode diskDrive, Filter filter) {
         this.compositeOfDisks = new CompositeStorageImpl<>(new ResourceListImpl<>());
         this.diskDrive = diskDrive;
         this.filter = filter;
@@ -43,9 +42,6 @@ public class DiskDriveStorage<T> implements CompositeStorage<T>, Priority {
 
     @Override
     public Collection<ResourceAmount<T>> getAll() {
-        if (!diskDrive.isActive()) {
-            return Collections.emptyList();
-        }
         return compositeOfDisks.getAll();
     }
 
@@ -82,5 +78,10 @@ public class DiskDriveStorage<T> implements CompositeStorage<T>, Priority {
     @Override
     public void removeListener(CompositeStorageListener<T> listener) {
         compositeOfDisks.removeListener(listener);
+    }
+
+    @Override
+    public void clearSources() {
+        compositeOfDisks.clearSources();
     }
 }

--- a/refinedstorage2-network-api/src/test/java/com/refinedmods/refinedstorage2/api/network/component/StorageNetworkComponentTest.java
+++ b/refinedstorage2-network-api/src/test/java/com/refinedmods/refinedstorage2/api/network/component/StorageNetworkComponentTest.java
@@ -13,6 +13,7 @@ import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannel;
 import com.refinedmods.refinedstorage2.test.Rs2Test;
 
 import java.util.Collection;
+import java.util.HashSet;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ class StorageNetworkComponentTest {
         diskDrive.setListener(mock(DiskDriveListener.class));
         diskDrive.setDiskProvider(storageProviderRepository);
         diskDrive.initialize(storageProviderRepository);
+        diskDrive.onActiveChanged(true);
 
         diskDriveContainer = () -> diskDrive;
     }
@@ -76,7 +78,7 @@ class StorageNetworkComponentTest {
 
         sut.onContainerAdded(diskDriveContainer);
 
-        Collection<ResourceAmount<String>> resourcesBeforeRemoval = storageChannel.getAll();
+        Collection<ResourceAmount<String>> resourcesBeforeRemoval = new HashSet<>(storageChannel.getAll());
 
         // Act
         sut.onContainerRemoved(diskDriveContainer);

--- a/refinedstorage2-network-api/src/test/java/com/refinedmods/refinedstorage2/api/network/node/diskdrive/DiskDriveNetworkNodeTest.java
+++ b/refinedstorage2-network-api/src/test/java/com/refinedmods/refinedstorage2/api/network/node/diskdrive/DiskDriveNetworkNodeTest.java
@@ -107,7 +107,9 @@ class DiskDriveNetworkNodeTest {
         assertThat(storageOf(sut).getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
                 new ResourceAmount<>("A", 5)
         );
-        assertThat(fakeStorageChannelOf(network).getAll()).isEmpty();
+        assertThat(fakeStorageChannelOf(network).getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+                new ResourceAmount<>("A", 5)
+        );
         assertThat(storageOf(sut).getStored()).isEqualTo(5L);
     }
 
@@ -352,7 +354,7 @@ class DiskDriveNetworkNodeTest {
         storageProviderRepository.setInSlot(3, storage3);
 
         sut.initialize(storageProviderRepository);
-        fakeStorageChannelOf(network).invalidate();
+        //  fakeStorageChannelOf(network).invalidate();
 
         // Act
         long extracted = fakeStorageChannelOf(network).extract("A", 85, Action.EXECUTE);

--- a/refinedstorage2-network-api/src/test/java/com/refinedmods/refinedstorage2/api/network/test/StorageChannelTypes.java
+++ b/refinedstorage2-network-api/src/test/java/com/refinedmods/refinedstorage2/api/network/test/StorageChannelTypes.java
@@ -1,33 +1,11 @@
 package com.refinedmods.refinedstorage2.api.network.test;
 
-import com.refinedmods.refinedstorage2.api.resource.list.ResourceListImpl;
-import com.refinedmods.refinedstorage2.api.storage.Storage;
-import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannel;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannelImpl;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannelType;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageTracker;
-import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorage;
-import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorageImpl;
-
-import java.util.Collections;
-import java.util.List;
 
 public final class StorageChannelTypes {
-    public static final StorageChannelType<String> FAKE = new StorageChannelType<>() {
-        @Override
-        public StorageChannel<String> create() {
-            return new StorageChannelImpl<>(
-                    createCompositeStorage(Collections.emptyList()),
-                    ResourceListImpl::new,
-                    new StorageTracker<>(System::currentTimeMillis)
-            );
-        }
-
-        @Override
-        public CompositeStorage<String> createCompositeStorage(List<Storage<String>> sources) {
-            return new CompositeStorageImpl<>(sources, new ResourceListImpl<>());
-        }
-    };
+    public static final StorageChannelType<String> FAKE = () -> new StorageChannelImpl<>(new StorageTracker<>(System::currentTimeMillis));
 
     private StorageChannelTypes() {
     }

--- a/refinedstorage2-network-api/src/test/java/com/refinedmods/refinedstorage2/api/network/test/StorageChannelTypes.java
+++ b/refinedstorage2-network-api/src/test/java/com/refinedmods/refinedstorage2/api/network/test/StorageChannelTypes.java
@@ -7,6 +7,7 @@ import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannelImpl;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannelType;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageTracker;
 import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorage;
+import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorageImpl;
 
 import java.util.Collections;
 import java.util.List;
@@ -24,7 +25,7 @@ public final class StorageChannelTypes {
 
         @Override
         public CompositeStorage<String> createCompositeStorage(List<Storage<String>> sources) {
-            return new CompositeStorage<>(sources, new ResourceListImpl<>());
+            return new CompositeStorageImpl<>(sources, new ResourceListImpl<>());
         }
     };
 

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/storage/channel/SimpleStorageChannelType.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/storage/channel/SimpleStorageChannelType.java
@@ -1,16 +1,9 @@
 package com.refinedmods.refinedstorage2.platform.common.internal.storage.channel;
 
-import com.refinedmods.refinedstorage2.api.resource.list.ResourceListImpl;
-import com.refinedmods.refinedstorage2.api.storage.Storage;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannel;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannelImpl;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannelType;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageTracker;
-import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorage;
-import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorageImpl;
-
-import java.util.Collections;
-import java.util.List;
 
 public class SimpleStorageChannelType<T> implements StorageChannelType<T> {
     private final String name;
@@ -21,16 +14,7 @@ public class SimpleStorageChannelType<T> implements StorageChannelType<T> {
 
     @Override
     public StorageChannel<T> create() {
-        return new StorageChannelImpl<>(
-                createCompositeStorage(Collections.emptyList()),
-                ResourceListImpl::new,
-                new StorageTracker<>(System::currentTimeMillis)
-        );
-    }
-
-    @Override
-    public CompositeStorage<T> createCompositeStorage(List<Storage<T>> sources) {
-        return new CompositeStorageImpl<>(sources, new ResourceListImpl<>());
+        return new StorageChannelImpl<>(new StorageTracker<>(System::currentTimeMillis));
     }
 
     @Override

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/storage/channel/SimpleStorageChannelType.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/storage/channel/SimpleStorageChannelType.java
@@ -7,6 +7,7 @@ import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannelImpl;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannelType;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageTracker;
 import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorage;
+import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorageImpl;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +30,7 @@ public class SimpleStorageChannelType<T> implements StorageChannelType<T> {
 
     @Override
     public CompositeStorage<T> createCompositeStorage(List<Storage<T>> sources) {
-        return new CompositeStorage<>(sources, new ResourceListImpl<>());
+        return new CompositeStorageImpl<>(sources, new ResourceListImpl<>());
     }
 
     @Override

--- a/refinedstorage2-resource-api/src/main/java/com/refinedmods/refinedstorage2/api/resource/list/listenable/ListenableResourceList.java
+++ b/refinedstorage2-resource-api/src/main/java/com/refinedmods/refinedstorage2/api/resource/list/listenable/ListenableResourceList.java
@@ -4,6 +4,7 @@ import com.refinedmods.refinedstorage2.api.resource.list.ProxyResourceList;
 import com.refinedmods.refinedstorage2.api.resource.list.ResourceList;
 import com.refinedmods.refinedstorage2.api.resource.list.ResourceListOperationResult;
 
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -19,11 +20,10 @@ import org.apiguardian.api.API;
  */
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.1.2")
 public class ListenableResourceList<T> extends ProxyResourceList<T> {
-    private final Set<ResourceListListener<T>> listeners;
+    private final Set<ResourceListListener<T>> listeners = new HashSet<>();
 
-    public ListenableResourceList(ResourceList<T> parent, Set<ResourceListListener<T>> listeners) {
+    public ListenableResourceList(ResourceList<T> parent) {
         super(parent);
-        this.listeners = listeners;
     }
 
     @Override
@@ -40,5 +40,13 @@ public class ListenableResourceList<T> extends ProxyResourceList<T> {
                     listeners.forEach(listener -> listener.onChanged(result));
                     return result;
                 });
+    }
+
+    public void addListener(ResourceListListener<T> listener) {
+        listeners.add(listener);
+    }
+
+    public void removeListener(ResourceListListener<T> listener) {
+        listeners.remove(listener);
     }
 }

--- a/refinedstorage2-resource-api/src/test/java/com/refinedmods/refinedstorage2/api/resource/list/listenable/ListenableResourceListTest.java
+++ b/refinedstorage2-resource-api/src/test/java/com/refinedmods/refinedstorage2/api/resource/list/listenable/ListenableResourceListTest.java
@@ -6,7 +6,6 @@ import com.refinedmods.refinedstorage2.test.Rs2Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,43 +16,69 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ListenableResourceListTest {
     private FakeResourceListListener<String> listener;
     private ResourceListImpl<String> list;
-    private ListenableResourceList<String> listenable;
+    private ListenableResourceList<String> sut;
 
     @BeforeEach
     void setUp() {
         listener = new FakeResourceListListener<>();
         list = new ResourceListImpl<>();
-        listenable = new ListenableResourceList<>(list, Set.of(listener));
+        sut = new ListenableResourceList<>(list);
     }
 
     @Test
     void Test_should_call_listener_when_adding() {
+        // Arrange
+        sut.addListener(listener);
+
         // Act
-        listenable.add("A", 10);
+        sut.add("A", 10);
 
         // Assert
         assertThat(listener.changes).hasSize(1);
     }
 
     @Test
+    void Test_should_not_call_listener_when_adding_without_listener() {
+        // Act
+        sut.add("A", 10);
+
+        // Assert
+        assertThat(listener.changes).isEmpty();
+    }
+
+    @Test
     void Test_should_call_listener_when_removing() {
         // Arrange
-        listenable.add("A", 10);
+        sut.addListener(listener);
+        sut.add("A", 10);
 
         // Act
-        listenable.remove("A", 10);
+        sut.remove("A", 10);
 
         // Assert
         assertThat(listener.changes).hasSize(2);
     }
 
     @Test
-    void Test_should_not_call_listener_when_removing_with_no_result() {
+    void Test_should_not_call_listener_when_removing_without_listener() {
         // Arrange
-        listenable.add("A", 10);
+        sut.add("A", 10);
 
         // Act
-        listenable.remove("B", 10);
+        sut.remove("A", 10);
+
+        // Assert
+        assertThat(listener.changes).isEmpty();
+    }
+
+    @Test
+    void Test_should_not_call_listener_when_removing_with_no_result() {
+        // Arrange
+        sut.addListener(listener);
+        sut.add("A", 10);
+
+        // Act
+        sut.remove("B", 10);
 
         // Assert
         assertThat(listener.changes).hasSize(1);
@@ -62,10 +87,23 @@ public class ListenableResourceListTest {
     @Test
     void Test_should_not_call_listener_when_calling_list_directly() {
         // Act
+        sut.addListener(listener);
         list.add("A", 10);
 
         // Assert
         assertThat(listener.changes).isEmpty();
+    }
+
+    @Test
+    void Test_should_be_able_to_remove_listener() {
+        // Act
+        sut.addListener(listener);
+        sut.add("A", 10);
+        sut.removeListener(listener);
+        sut.add("A", 10);
+
+        // Assert
+        assertThat(listener.changes).hasSize(1);
     }
 
     private static class FakeResourceListListener<R> implements ResourceListListener<R> {

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/channel/StorageChannel.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/channel/StorageChannel.java
@@ -73,8 +73,6 @@ public interface StorageChannel<T> extends Storage<T> {
 
     /**
      * Adds a source to the channel.
-     * This should invalidate the backing storage.
-     * This is an expensive operation and should be done with care.
      *
      * @param source the source
      */
@@ -82,16 +80,8 @@ public interface StorageChannel<T> extends Storage<T> {
 
     /**
      * Removes a source from the channel.
-     * This should invalidate the backing storage.
-     * This is an expensive operation and should be done with care.
      *
      * @param source the source
      */
     void removeSource(Storage<?> source);
-
-    /**
-     * Invalidates the backing storage.
-     * This is an expensive operation and should be done with care.
-     */
-    void invalidate();
 }

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/channel/StorageChannelImpl.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/channel/StorageChannelImpl.java
@@ -8,6 +8,7 @@ import com.refinedmods.refinedstorage2.api.resource.list.listenable.ResourceList
 import com.refinedmods.refinedstorage2.api.storage.Source;
 import com.refinedmods.refinedstorage2.api.storage.Storage;
 import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorage;
+import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorageImpl;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -27,7 +28,7 @@ public class StorageChannelImpl<T> implements StorageChannel<T> {
     public StorageChannelImpl(StorageTracker<T> tracker) {
         this.tracker = tracker;
         this.list = new ListenableResourceList<>(new ResourceListImpl<>());
-        this.storage = new CompositeStorage<>(list);
+        this.storage = new CompositeStorageImpl<>(list);
     }
 
     @Override

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/channel/StorageChannelImpl.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/channel/StorageChannelImpl.java
@@ -2,49 +2,32 @@ package com.refinedmods.refinedstorage2.api.storage.channel;
 
 import com.refinedmods.refinedstorage2.api.core.Action;
 import com.refinedmods.refinedstorage2.api.resource.ResourceAmount;
-import com.refinedmods.refinedstorage2.api.resource.list.ResourceList;
+import com.refinedmods.refinedstorage2.api.resource.list.ResourceListImpl;
 import com.refinedmods.refinedstorage2.api.resource.list.listenable.ListenableResourceList;
 import com.refinedmods.refinedstorage2.api.resource.list.listenable.ResourceListListener;
 import com.refinedmods.refinedstorage2.api.storage.Source;
 import com.refinedmods.refinedstorage2.api.storage.Storage;
 import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorage;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.Supplier;
 
 import com.google.common.base.Preconditions;
 import org.apiguardian.api.API;
 
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.1.0")
 public class StorageChannelImpl<T> implements StorageChannel<T> {
-    private final Supplier<ResourceList<T>> listFactory;
     private final StorageTracker<T> tracker;
-    private final Set<ResourceListListener<T>> listeners = new HashSet<>();
-    private ListenableResourceList<T> list;
-    private CompositeStorage<T> storage;
-    private final List<Storage<T>> sources = new ArrayList<>();
+    private final ListenableResourceList<T> list;
+    private final CompositeStorage<T> storage;
 
     /**
-     * @param storage     the backing {@link CompositeStorage}
-     * @param listFactory a supplier for the backing list of the {@link CompositeStorage}
-     * @param tracker     the storage tracker
+     * @param tracker the storage tracker
      */
-    public StorageChannelImpl(CompositeStorage<T> storage, Supplier<ResourceList<T>> listFactory, StorageTracker<T> tracker) {
-        this.listFactory = listFactory;
+    public StorageChannelImpl(StorageTracker<T> tracker) {
         this.tracker = tracker;
-        this.storage = storage;
-    }
-
-    @Override
-    public void invalidate() {
-        this.list = new ListenableResourceList<>(listFactory.get(), listeners);
-        this.storage = new CompositeStorage<>(sources, list);
-        sortSources();
+        this.list = new ListenableResourceList<>(new ResourceListImpl<>());
+        this.storage = new CompositeStorage<>(list);
     }
 
     @Override
@@ -54,24 +37,22 @@ public class StorageChannelImpl<T> implements StorageChannel<T> {
 
     @Override
     public void addSource(Storage<?> source) {
-        sources.add((Storage<T>) source);
-        invalidate();
+        storage.addSource((Storage<T>) source);
     }
 
     @Override
     public void removeSource(Storage<?> source) {
-        sources.remove((Storage<T>) source);
-        invalidate();
+        storage.removeSource((Storage<T>) source);
     }
 
     @Override
     public void addListener(ResourceListListener<T> listener) {
-        listeners.add(listener);
+        list.addListener(listener);
     }
 
     @Override
     public void removeListener(ResourceListListener<T> listener) {
-        listeners.remove(listener);
+        list.removeListener(listener);
     }
 
     @Override

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/channel/StorageChannelType.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/channel/StorageChannelType.java
@@ -1,15 +1,8 @@
 package com.refinedmods.refinedstorage2.api.storage.channel;
 
-import com.refinedmods.refinedstorage2.api.storage.Storage;
-import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorage;
-
-import java.util.List;
-
 import org.apiguardian.api.API;
 
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.1.0")
 public interface StorageChannelType<T> {
     StorageChannel<T> create();
-
-    CompositeStorage<T> createCompositeStorage(List<Storage<T>> sources);
 }

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorage.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorage.java
@@ -5,6 +5,7 @@ import com.refinedmods.refinedstorage2.api.resource.ResourceAmount;
 import com.refinedmods.refinedstorage2.api.resource.list.ResourceList;
 import com.refinedmods.refinedstorage2.api.storage.Storage;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -17,19 +18,14 @@ import org.apiguardian.api.API;
  */
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.1.0")
 public class CompositeStorage<T> implements Storage<T> {
-    private final List<Storage<T>> sources;
+    private final List<Storage<T>> sources = new ArrayList<>();
     private final ResourceList<T> list;
 
     /**
-     * @param sources the sources for this composite storage
-     * @param list    the backing list of this composite storage, used to retrieve a view of the sources
+     * @param list the backing list of this composite storage, used to retrieve a view of the sources
      */
-    public CompositeStorage(List<Storage<T>> sources, ResourceList<T> list) {
-        this.sources = sources;
+    public CompositeStorage(ResourceList<T> list) {
         this.list = list;
-
-        fillListFromSources();
-        sortSources();
     }
 
     /**
@@ -40,8 +36,16 @@ public class CompositeStorage<T> implements Storage<T> {
         sources.sort(PrioritizedStorageComparator.INSTANCE);
     }
 
-    private void fillListFromSources() {
-        sources.forEach(source -> source.getAll().forEach(list::add));
+    public void addSource(Storage<T> source) {
+        sources.add(source);
+        sortSources();
+        source.getAll().forEach(list::add);
+    }
+
+    public void removeSource(Storage<T> source) {
+        sources.remove(source);
+        sortSources();
+        source.getAll().forEach(resourceAmount -> list.remove(resourceAmount.getResource(), resourceAmount.getAmount()));
     }
 
     @Override

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorage.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorage.java
@@ -4,15 +4,45 @@ import com.refinedmods.refinedstorage2.api.storage.Storage;
 
 import org.apiguardian.api.API;
 
+/**
+ * This represents a single storage that can be backed by multiple storages.
+ *
+ * @param <T> the type of resource
+ */
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.1.0")
 public interface CompositeStorage<T> extends Storage<T> {
+    /**
+     * Sort the sources of this composite.
+     * If a storage implements {@link Priority}, the composite will account for this.
+     */
     void sortSources();
 
+    /**
+     * Adds a source and resorts the composite storage.
+     *
+     * @param source the source
+     */
     void addSource(Storage<T> source);
 
+    /**
+     * Removes a source and resorts the composite storage.
+     *
+     * @param source the source
+     */
     void removeSource(Storage<T> source);
 
+    /**
+     * Clears all sources.
+     */
+    void clearSources();
+
+    /**
+     * @param listener the listener
+     */
     void addListener(CompositeStorageListener<T> listener);
 
+    /**
+     * @param listener the listener
+     */
     void removeListener(CompositeStorageListener<T> listener);
 }

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorage.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorage.java
@@ -11,4 +11,8 @@ public interface CompositeStorage<T> extends Storage<T> {
     void addSource(Storage<T> source);
 
     void removeSource(Storage<T> source);
+
+    void addListener(CompositeStorageListener<T> listener);
+
+    void removeListener(CompositeStorageListener<T> listener);
 }

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorage.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorage.java
@@ -1,105 +1,14 @@
 package com.refinedmods.refinedstorage2.api.storage.composite;
 
-import com.refinedmods.refinedstorage2.api.core.Action;
-import com.refinedmods.refinedstorage2.api.resource.ResourceAmount;
-import com.refinedmods.refinedstorage2.api.resource.list.ResourceList;
 import com.refinedmods.refinedstorage2.api.storage.Storage;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 
 import org.apiguardian.api.API;
 
-/**
- * This represents a single storage that can be backed by multiple storages.
- *
- * @param <T> the type of resource
- */
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.1.0")
-public class CompositeStorage<T> implements Storage<T> {
-    private final List<Storage<T>> sources = new ArrayList<>();
-    private final ResourceList<T> list;
+public interface CompositeStorage<T> extends Storage<T> {
+    void sortSources();
 
-    /**
-     * @param list the backing list of this composite storage, used to retrieve a view of the sources
-     */
-    public CompositeStorage(ResourceList<T> list) {
-        this.list = list;
-    }
+    void addSource(Storage<T> source);
 
-    /**
-     * Sort the sources of this composite.
-     * If a storage implements {@link Priority}, the composite will account for this.
-     */
-    public void sortSources() {
-        sources.sort(PrioritizedStorageComparator.INSTANCE);
-    }
-
-    public void addSource(Storage<T> source) {
-        sources.add(source);
-        sortSources();
-        source.getAll().forEach(list::add);
-    }
-
-    public void removeSource(Storage<T> source) {
-        sources.remove(source);
-        sortSources();
-        source.getAll().forEach(resourceAmount -> list.remove(resourceAmount.getResource(), resourceAmount.getAmount()));
-    }
-
-    @Override
-    public long extract(T resource, long amount, Action action) {
-        long extracted = extractFromStorages(resource, amount, action);
-        if (action == Action.EXECUTE && extracted > 0) {
-            list.remove(resource, extracted);
-        }
-        return extracted;
-    }
-
-    private long extractFromStorages(T template, long amount, Action action) {
-        long remaining = amount;
-        for (Storage<T> source : sources) {
-            long extracted = source.extract(template, remaining, action);
-            remaining -= extracted;
-            if (remaining == 0) {
-                break;
-            }
-        }
-
-        return amount - remaining;
-    }
-
-    @Override
-    public long insert(T resource, long amount, Action action) {
-        long remainder = insertIntoStorages(resource, amount, action);
-        if (action == Action.EXECUTE) {
-            long inserted = amount - remainder;
-            if (inserted > 0) {
-                list.add(resource, inserted);
-            }
-        }
-        return remainder;
-    }
-
-    private long insertIntoStorages(T template, long amount, Action action) {
-        long remainder = amount;
-        for (Storage<T> source : sources) {
-            remainder = source.insert(template, remainder, action);
-            if (remainder == 0) {
-                break;
-            }
-        }
-        return remainder;
-    }
-
-    @Override
-    public Collection<ResourceAmount<T>> getAll() {
-        return list.getAll();
-    }
-
-    @Override
-    public long getStored() {
-        return sources.stream().mapToLong(Storage::getStored).sum();
-    }
+    void removeSource(Storage<T> source);
 }

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorageImpl.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorageImpl.java
@@ -1,0 +1,108 @@
+package com.refinedmods.refinedstorage2.api.storage.composite;
+
+import com.refinedmods.refinedstorage2.api.core.Action;
+import com.refinedmods.refinedstorage2.api.resource.ResourceAmount;
+import com.refinedmods.refinedstorage2.api.resource.list.ResourceList;
+import com.refinedmods.refinedstorage2.api.storage.Storage;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apiguardian.api.API;
+
+/**
+ * This represents a single storage that can be backed by multiple storages.
+ *
+ * @param <T> the type of resource
+ */
+@API(status = API.Status.STABLE, since = "2.0.0-milestone.1.0")
+public class CompositeStorageImpl<T> implements CompositeStorage<T> {
+    private final List<Storage<T>> sources = new ArrayList<>();
+    private final ResourceList<T> list;
+
+    /**
+     * @param list the backing list of this composite storage, used to retrieve a view of the sources
+     */
+    public CompositeStorageImpl(ResourceList<T> list) {
+        this.list = list;
+    }
+
+    /**
+     * Sort the sources of this composite.
+     * If a storage implements {@link Priority}, the composite will account for this.
+     */
+    @Override
+    public void sortSources() {
+        sources.sort(PrioritizedStorageComparator.INSTANCE);
+    }
+
+    @Override
+    public void addSource(Storage<T> source) {
+        sources.add(source);
+        sortSources();
+        source.getAll().forEach(list::add);
+    }
+
+    @Override
+    public void removeSource(Storage<T> source) {
+        sources.remove(source);
+        sortSources();
+        source.getAll().forEach(resourceAmount -> list.remove(resourceAmount.getResource(), resourceAmount.getAmount()));
+    }
+
+    @Override
+    public long extract(T resource, long amount, Action action) {
+        long extracted = extractFromStorages(resource, amount, action);
+        if (action == Action.EXECUTE && extracted > 0) {
+            list.remove(resource, extracted);
+        }
+        return extracted;
+    }
+
+    private long extractFromStorages(T template, long amount, Action action) {
+        long remaining = amount;
+        for (Storage<T> source : sources) {
+            long extracted = source.extract(template, remaining, action);
+            remaining -= extracted;
+            if (remaining == 0) {
+                break;
+            }
+        }
+
+        return amount - remaining;
+    }
+
+    @Override
+    public long insert(T resource, long amount, Action action) {
+        long remainder = insertIntoStorages(resource, amount, action);
+        if (action == Action.EXECUTE) {
+            long inserted = amount - remainder;
+            if (inserted > 0) {
+                list.add(resource, inserted);
+            }
+        }
+        return remainder;
+    }
+
+    private long insertIntoStorages(T template, long amount, Action action) {
+        long remainder = amount;
+        for (Storage<T> source : sources) {
+            remainder = source.insert(template, remainder, action);
+            if (remainder == 0) {
+                break;
+            }
+        }
+        return remainder;
+    }
+
+    @Override
+    public Collection<ResourceAmount<T>> getAll() {
+        return list.getAll();
+    }
+
+    @Override
+    public long getStored() {
+        return sources.stream().mapToLong(Storage::getStored).sum();
+    }
+}

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorageImpl.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorageImpl.java
@@ -13,11 +13,6 @@ import java.util.Set;
 
 import org.apiguardian.api.API;
 
-/**
- * This represents a single storage that can be backed by multiple storages.
- *
- * @param <T> the type of resource
- */
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.1.0")
 public class CompositeStorageImpl<T> implements CompositeStorage<T>, CompositeStorageListener<T> {
     private final List<Storage<T>> sources = new ArrayList<>();
@@ -31,10 +26,6 @@ public class CompositeStorageImpl<T> implements CompositeStorage<T>, CompositeSt
         this.list = list;
     }
 
-    /**
-     * Sort the sources of this composite.
-     * If a storage implements {@link Priority}, the composite will account for this.
-     */
     @Override
     public void sortSources() {
         sources.sort(PrioritizedStorageComparator.INSTANCE);
@@ -60,6 +51,12 @@ public class CompositeStorageImpl<T> implements CompositeStorage<T>, CompositeSt
         if (source instanceof CompositeStorage<T> childComposite) {
             childComposite.removeListener(this);
         }
+    }
+
+    @Override
+    public void clearSources() {
+        Set<Storage<T>> oldSources = new HashSet<>(sources);
+        oldSources.forEach(this::removeSource);
     }
 
     @Override

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorageListener.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorageListener.java
@@ -1,0 +1,9 @@
+package com.refinedmods.refinedstorage2.api.storage.composite;
+
+import com.refinedmods.refinedstorage2.api.storage.Storage;
+
+public interface CompositeStorageListener<T> {
+    void onSourceAdded(Storage<T> source);
+
+    void onSourceRemoved(Storage<T> source);
+}

--- a/refinedstorage2-storage-api/src/test/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorageImplTest.java
+++ b/refinedstorage2-storage-api/src/test/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorageImplTest.java
@@ -15,12 +15,12 @@ import org.junit.jupiter.params.provider.EnumSource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Rs2Test
-class CompositeStorageTest {
-    private CompositeStorage<String> sut;
+class CompositeStorageImplTest {
+    private CompositeStorageImpl<String> sut;
 
     @BeforeEach
     void setUp() {
-        sut = new CompositeStorage<>(new ResourceListImpl<>());
+        sut = new CompositeStorageImpl<>(new ResourceListImpl<>());
     }
 
     @Test


### PR DESCRIPTION
Stop invalidating the entire storage channel when a source is added/removed.

This should improve performance a bit and should ensure that the grid is notified of deletions as well to fix bug #19 