### PR TITLE
Composite storage listener cleanup

### DIFF
--- a/refinedstorage2-network-api/src/main/java/com/refinedmods/refinedstorage2/api/network/node/diskdrive/DiskDriveCompositeStorage.java
+++ b/refinedstorage2-network-api/src/main/java/com/refinedmods/refinedstorage2/api/network/node/diskdrive/DiskDriveCompositeStorage.java
@@ -7,17 +7,18 @@ import com.refinedmods.refinedstorage2.api.resource.list.ResourceListImpl;
 import com.refinedmods.refinedstorage2.api.storage.AccessMode;
 import com.refinedmods.refinedstorage2.api.storage.Source;
 import com.refinedmods.refinedstorage2.api.storage.Storage;
+import com.refinedmods.refinedstorage2.api.storage.composite.CompositeAwareChild;
 import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorage;
 import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorageImpl;
-import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorageListener;
+import com.refinedmods.refinedstorage2.api.storage.composite.ParentComposite;
 import com.refinedmods.refinedstorage2.api.storage.composite.Priority;
 import com.refinedmods.refinedstorage2.api.storage.tracked.TrackedResource;
 
 import java.util.Collection;
 import java.util.Optional;
 
-public class DiskDriveCompositeStorage<T> implements CompositeStorage<T>, Priority {
-    private final CompositeStorage<T> disks;
+class DiskDriveCompositeStorage<T> implements CompositeStorage<T>, CompositeAwareChild<T>, Priority {
+    private final CompositeStorageImpl<T> disks;
     private final DiskDriveNetworkNode diskDrive;
     private final Filter filter;
 
@@ -74,16 +75,6 @@ public class DiskDriveCompositeStorage<T> implements CompositeStorage<T>, Priori
     }
 
     @Override
-    public void addListener(CompositeStorageListener<T> listener) {
-        disks.addListener(listener);
-    }
-
-    @Override
-    public void removeListener(CompositeStorageListener<T> listener) {
-        disks.removeListener(listener);
-    }
-
-    @Override
     public void clearSources() {
         disks.clearSources();
     }
@@ -91,5 +82,15 @@ public class DiskDriveCompositeStorage<T> implements CompositeStorage<T>, Priori
     @Override
     public Optional<TrackedResource> findTrackedResourceBySourceType(T resource, Class<? extends Source> sourceType) {
         return disks.findTrackedResourceBySourceType(resource, sourceType);
+    }
+
+    @Override
+    public void onAddedIntoComposite(ParentComposite<T> parentComposite) {
+        disks.onAddedIntoComposite(parentComposite);
+    }
+
+    @Override
+    public void onRemovedFromComposite(ParentComposite<T> parentComposite) {
+        disks.onRemovedFromComposite(parentComposite);
     }
 }

--- a/refinedstorage2-network-api/src/main/java/com/refinedmods/refinedstorage2/api/network/node/storage/NetworkNodeStorage.java
+++ b/refinedstorage2-network-api/src/main/java/com/refinedmods/refinedstorage2/api/network/node/storage/NetworkNodeStorage.java
@@ -1,0 +1,95 @@
+package com.refinedmods.refinedstorage2.api.network.node.storage;
+
+import com.refinedmods.refinedstorage2.api.core.Action;
+import com.refinedmods.refinedstorage2.api.resource.ResourceAmount;
+import com.refinedmods.refinedstorage2.api.storage.AccessMode;
+import com.refinedmods.refinedstorage2.api.storage.Source;
+import com.refinedmods.refinedstorage2.api.storage.Storage;
+import com.refinedmods.refinedstorage2.api.storage.composite.CompositeAwareChild;
+import com.refinedmods.refinedstorage2.api.storage.composite.ParentComposite;
+import com.refinedmods.refinedstorage2.api.storage.composite.Priority;
+import com.refinedmods.refinedstorage2.api.storage.limited.LimitedStorage;
+import com.refinedmods.refinedstorage2.api.storage.tracked.TrackedResource;
+import com.refinedmods.refinedstorage2.api.storage.tracked.TrackedStorage;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import com.google.common.base.Preconditions;
+
+class NetworkNodeStorage<T> implements TrackedStorage<T>, Priority, CompositeAwareChild<T> {
+    private final StorageNetworkNode<T> networkNode;
+    private final Set<ParentComposite<T>> parentComposites = new HashSet<>();
+    private Storage<T> storage;
+
+    public NetworkNodeStorage(StorageNetworkNode<T> networkNode) {
+        this.networkNode = networkNode;
+    }
+
+    @Override
+    public long extract(T resource, long amount, Action action, Source source) {
+        if (storage == null || networkNode.getAccessMode() == AccessMode.INSERT || !networkNode.isActive()) {
+            return 0;
+        }
+        return storage.extract(resource, amount, action, source);
+    }
+
+    @Override
+    public long insert(T resource, long amount, Action action, Source source) {
+        if (storage == null || networkNode.getAccessMode() == AccessMode.EXTRACT || !networkNode.isActive() || !networkNode.isAllowed(resource)) {
+            return 0;
+        }
+        return storage.insert(resource, amount, action, source);
+    }
+
+    @Override
+    public Optional<TrackedResource> findTrackedResourceBySourceType(T resource, Class<? extends Source> sourceType) {
+        return storage instanceof TrackedStorage<T> trackedStorage
+                ? trackedStorage.findTrackedResourceBySourceType(resource, sourceType)
+                : Optional.empty();
+    }
+
+    @Override
+    public int getPriority() {
+        return networkNode.getPriority();
+    }
+
+    @Override
+    public void onAddedIntoComposite(ParentComposite<T> parentComposite) {
+        parentComposites.add(parentComposite);
+    }
+
+    @Override
+    public void onRemovedFromComposite(ParentComposite<T> parentComposite) {
+        parentComposites.remove(parentComposite);
+    }
+
+    @Override
+    public Collection<ResourceAmount<T>> getAll() {
+        return storage == null ? Collections.emptySet() : storage.getAll();
+    }
+
+    @Override
+    public long getStored() {
+        return storage == null ? 0L : storage.getStored();
+    }
+
+    public long getCapacity() {
+        return storage instanceof LimitedStorage<?> limitedStorage ? limitedStorage.getCapacity() : 0L;
+    }
+
+    public void setSource(Storage<T> source) {
+        Preconditions.checkNotNull(source);
+        this.storage = source;
+        parentComposites.forEach(parentComposite -> parentComposite.onSourceAddedToChild(storage));
+    }
+
+    public void removeSource() {
+        Preconditions.checkNotNull(this.storage);
+        parentComposites.forEach(parentComposite -> parentComposite.onSourceRemovedFromChild(this.storage));
+        this.storage = null;
+    }
+}

--- a/refinedstorage2-network-api/src/main/java/com/refinedmods/refinedstorage2/api/network/node/storage/StorageNetworkNode.java
+++ b/refinedstorage2-network-api/src/main/java/com/refinedmods/refinedstorage2/api/network/node/storage/StorageNetworkNode.java
@@ -1,28 +1,15 @@
 package com.refinedmods.refinedstorage2.api.network.node.storage;
 
-import com.refinedmods.refinedstorage2.api.core.Action;
 import com.refinedmods.refinedstorage2.api.core.filter.Filter;
 import com.refinedmods.refinedstorage2.api.core.filter.FilterMode;
 import com.refinedmods.refinedstorage2.api.network.component.StorageNetworkComponent;
 import com.refinedmods.refinedstorage2.api.network.component.StorageProvider;
 import com.refinedmods.refinedstorage2.api.network.node.NetworkNodeImpl;
-import com.refinedmods.refinedstorage2.api.resource.ResourceAmount;
-import com.refinedmods.refinedstorage2.api.resource.list.ResourceListImpl;
 import com.refinedmods.refinedstorage2.api.storage.AccessMode;
-import com.refinedmods.refinedstorage2.api.storage.ProxyStorage;
-import com.refinedmods.refinedstorage2.api.storage.Source;
 import com.refinedmods.refinedstorage2.api.storage.Storage;
 import com.refinedmods.refinedstorage2.api.storage.StorageRepository;
 import com.refinedmods.refinedstorage2.api.storage.channel.StorageChannelType;
-import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorage;
-import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorageImpl;
-import com.refinedmods.refinedstorage2.api.storage.composite.CompositeStorageListener;
-import com.refinedmods.refinedstorage2.api.storage.composite.Priority;
-import com.refinedmods.refinedstorage2.api.storage.limited.LimitedStorage;
-import com.refinedmods.refinedstorage2.api.storage.tracked.TrackedResource;
-import com.refinedmods.refinedstorage2.api.storage.tracked.TrackedStorage;
 
-import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -37,48 +24,45 @@ public class StorageNetworkNode<T> extends NetworkNodeImpl implements StoragePro
     private final long energyUsage;
     private final Filter filter = new Filter();
     private final StorageChannelType<?> type;
+    private final NetworkNodeStorage<T> exposedStorage = new NetworkNodeStorage<>(this);
 
     private int priority;
     private AccessMode accessMode = AccessMode.INSERT_EXTRACT;
-    private NetworkNodeStorage storage;
-    // In order to be able to "hide" the underlying storage when the activeness changes, we have to
-    // expose a composite storage because such a storage can propagate updates to the parent composite.
-    // We can't let this network node itself control the storage channel,
-    // since that wouldn't work with network node removals or network merges/updates.
-    private final ExposedNetworkNodeStorage exposedStorage = new ExposedNetworkNodeStorage();
+    private Storage<T> internalStorage;
 
     public StorageNetworkNode(long energyUsage, StorageChannelType<?> type) {
         this.energyUsage = energyUsage;
         this.type = type;
     }
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public void initializeExistingStorage(StorageRepository storageRepository, UUID storageId) {
         storageRepository.get(storageId).ifPresentOrElse(
                 existingStorage -> {
                     LOGGER.info("Loaded existing storage {}", storageId);
-                    this.storage = new NetworkNodeStorage((Storage<T>) existingStorage);
+                    this.internalStorage = (Storage) existingStorage;
                 },
                 () -> LOGGER.warn("Storage {} was not found, ignoring", storageId)
         );
     }
 
-    public void initializeNewStorage(StorageRepository storageRepository, Storage<T> storage, UUID storageId) {
+    public void initializeNewStorage(StorageRepository storageRepository, Storage<T> newStorage, UUID storageId) {
         LOGGER.info("Loaded new storage {}", storageId);
-        storageRepository.set(storageId, storage);
-        this.storage = new NetworkNodeStorage(storage);
+        storageRepository.set(storageId, newStorage);
+        this.internalStorage = newStorage;
     }
 
     @Override
     public void onActiveChanged(boolean active) {
         super.onActiveChanged(active);
-        if (network == null || storage == null) {
+        if (network == null || internalStorage == null) {
             return;
         }
         LOGGER.info("Storage activeness got changed to '{}', updating underlying storage", active);
         if (active) {
-            exposedStorage.addSource(storage);
+            exposedStorage.setSource(internalStorage);
         } else {
-            exposedStorage.removeSource(storage);
+            exposedStorage.removeSource();
         }
     }
 
@@ -103,6 +87,10 @@ public class StorageNetworkNode<T> extends NetworkNodeImpl implements StoragePro
         return filter.getMode();
     }
 
+    public boolean isAllowed(T resource) {
+        return filter.isAllowed(resource);
+    }
+
     public void setFilterMode(FilterMode mode) {
         filter.setMode(mode);
     }
@@ -123,11 +111,11 @@ public class StorageNetworkNode<T> extends NetworkNodeImpl implements StoragePro
     }
 
     public long getStored() {
-        return storage != null ? storage.getStored() : 0L;
+        return exposedStorage.getStored();
     }
 
     public long getCapacity() {
-        return storage != null ? storage.getCapacity() : 0L;
+        return exposedStorage.getCapacity();
     }
 
     @Override
@@ -136,102 +124,5 @@ public class StorageNetworkNode<T> extends NetworkNodeImpl implements StoragePro
             return Optional.of((Storage<S>) exposedStorage);
         }
         return Optional.empty();
-    }
-
-    private class ExposedNetworkNodeStorage implements CompositeStorage<T>, TrackedStorage<T>, Priority {
-        private final CompositeStorage<T> compositeStorage = new CompositeStorageImpl<>(new ResourceListImpl<>());
-
-        @Override
-        public long extract(T resource, long amount, Action action, Source source) {
-            return compositeStorage.extract(resource, amount, action, source);
-        }
-
-        @Override
-        public long insert(T resource, long amount, Action action, Source source) {
-            return compositeStorage.insert(resource, amount, action, source);
-        }
-
-        @Override
-        public Collection<ResourceAmount<T>> getAll() {
-            return compositeStorage.getAll();
-        }
-
-        @Override
-        public long getStored() {
-            return compositeStorage.getStored();
-        }
-
-        @Override
-        public void sortSources() {
-            compositeStorage.sortSources();
-        }
-
-        @Override
-        public void addSource(Storage<T> source) {
-            compositeStorage.addSource(source);
-        }
-
-        @Override
-        public void removeSource(Storage<T> source) {
-            compositeStorage.removeSource(source);
-        }
-
-        @Override
-        public void clearSources() {
-            compositeStorage.clearSources();
-        }
-
-        @Override
-        public void addListener(CompositeStorageListener<T> listener) {
-            compositeStorage.addListener(listener);
-        }
-
-        @Override
-        public void removeListener(CompositeStorageListener<T> listener) {
-            compositeStorage.removeListener(listener);
-        }
-
-        @Override
-        public int getPriority() {
-            return priority;
-        }
-
-        @Override
-        public Optional<TrackedResource> findTrackedResourceBySourceType(T resource, Class<? extends Source> sourceType) {
-            return storage.findTrackedResourceBySourceType(resource, sourceType);
-        }
-    }
-
-    private class NetworkNodeStorage extends ProxyStorage<T> implements TrackedStorage<T> {
-        public NetworkNodeStorage(Storage<T> delegate) {
-            super(delegate);
-        }
-
-        private long getCapacity() {
-            return delegate instanceof LimitedStorage<?> limitedStorage ? limitedStorage.getCapacity() : 0L;
-        }
-
-        @Override
-        public long extract(T resource, long amount, Action action, Source source) {
-            if (accessMode == AccessMode.INSERT || !isActive()) {
-                return 0;
-            }
-            return super.extract(resource, amount, action, source);
-        }
-
-        @Override
-        public long insert(T resource, long amount, Action action, Source source) {
-            if (accessMode == AccessMode.EXTRACT || !isActive() || !filter.isAllowed(resource)) {
-                return 0;
-            }
-            return super.insert(resource, amount, action, source);
-        }
-
-        @Override
-        public Optional<TrackedResource> findTrackedResourceBySourceType(T resource, Class<? extends Source> sourceType) {
-            return delegate instanceof TrackedStorage<T> trackedStorage
-                    ? trackedStorage.findTrackedResourceBySourceType(resource, sourceType)
-                    : Optional.empty();
-        }
     }
 }

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeAwareChild.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeAwareChild.java
@@ -1,0 +1,27 @@
+package com.refinedmods.refinedstorage2.api.storage.composite;
+
+import org.apiguardian.api.API;
+
+/**
+ * Implement this on storages that need to be aware of the fact that they are contained in a {@link CompositeStorage}.
+ * Typically, this is needed so that storages that dynamically modify their underlying storage sources, can propagate
+ * the changes to the parent composite list.
+ *
+ * @param <T> the type of resource
+ */
+@API(status = API.Status.STABLE, since = "2.0.0-milestone.1.4")
+public interface CompositeAwareChild<T> {
+    /**
+     * Called by a {@link CompositeStorage} when this {@link CompositeAwareChild} is added into the composite storage.
+     *
+     * @param parentComposite the composite storage that this {@link CompositeAwareChild} is contained in
+     */
+    void onAddedIntoComposite(ParentComposite<T> parentComposite);
+
+    /**
+     * Called by a {@link CompositeStorage} when this {@link CompositeAwareChild} is removed from the composite storage.
+     *
+     * @param parentComposite the composite storage that this {@link CompositeAwareChild} is/was contained in
+     */
+    void onRemovedFromComposite(ParentComposite<T> parentComposite);
+}

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorage.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorage.java
@@ -13,20 +13,19 @@ import org.apiguardian.api.API;
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.1.0")
 public interface CompositeStorage<T> extends Storage<T>, TrackedStorage<T> {
     /**
-     * Sort the sources of this composite.
-     * If a storage implements {@link Priority}, the composite will account for this.
+     * Sorts storages that implement {@link Priority}.
      */
     void sortSources();
 
     /**
-     * Adds a source and resorts the composite storage.
+     * Adds a source and resorts them.
      *
      * @param source the source
      */
     void addSource(Storage<T> source);
 
     /**
-     * Removes a source and resorts the composite storage.
+     * Removes a source and resorts them.
      *
      * @param source the source
      */
@@ -36,14 +35,4 @@ public interface CompositeStorage<T> extends Storage<T>, TrackedStorage<T> {
      * Clears all sources.
      */
     void clearSources();
-
-    /**
-     * @param listener the listener
-     */
-    void addListener(CompositeStorageListener<T> listener);
-
-    /**
-     * @param listener the listener
-     */
-    void removeListener(CompositeStorageListener<T> listener);
 }

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorageListener.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/CompositeStorageListener.java
@@ -1,9 +1,0 @@
-package com.refinedmods.refinedstorage2.api.storage.composite;
-
-import com.refinedmods.refinedstorage2.api.storage.Storage;
-
-public interface CompositeStorageListener<T> {
-    void onSourceAdded(Storage<T> source);
-
-    void onSourceRemoved(Storage<T> source);
-}

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/ParentComposite.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/ParentComposite.java
@@ -1,0 +1,27 @@
+package com.refinedmods.refinedstorage2.api.storage.composite;
+
+import com.refinedmods.refinedstorage2.api.storage.Storage;
+
+import org.apiguardian.api.API;
+
+/**
+ * Represents the parent storage that a {@link CompositeAwareChild} can use to propagate changes to.
+ *
+ * @param <T> the type of resource
+ */
+@API(status = API.Status.STABLE, since = "2.0.0-milestone.1.4")
+public interface ParentComposite<T> {
+    /**
+     * Called by the {@link CompositeAwareChild} to notify to this parent composite storage that a source has been added.
+     *
+     * @param source the source
+     */
+    void onSourceAddedToChild(Storage<T> source);
+
+    /**
+     * Called by the {@link CompositeAwareChild} to notify to this parent composite storage that a source has been removed.
+     *
+     * @param source the source
+     */
+    void onSourceRemovedFromChild(Storage<T> source);
+}

--- a/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/Priority.java
+++ b/refinedstorage2-storage-api/src/main/java/com/refinedmods/refinedstorage2/api/storage/composite/Priority.java
@@ -3,8 +3,8 @@ package com.refinedmods.refinedstorage2.api.storage.composite;
 import org.apiguardian.api.API;
 
 /**
- * Implement this on storages that can be prioritized.
- * The {@link CompositeStorage} will account for this.
+ * Implement this on {@link com.refinedmods.refinedstorage2.api.storage.Storage}s that have a priority that
+ * are contained in an {@link CompositeStorage}.
  */
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.1.0")
 public interface Priority {


### PR DESCRIPTION
Remove CompositeStorageListener and introduce CompositeAwareChild/ParentComposite.

Removed the requirement that only CompositeStorages can "know" that they are in a CompositeStorage by introducing CompositeAwareChild. That means that NetworkNodeStorage no longer needs to be a CompositeStorage but just a CompositeAwareChild.

The CompositeStorageListener interface has been renamed to ParentComposite.