### PR TITLE
ci: no longer store version info in build.gradle

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,9 +30,26 @@ easier to write commit messages.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-When porting to a new (binary-breaking) Minecraft version, the minor version number needs to be incremented.
-That way, we can still keep maintaining the previous Minecraft version if necessary without being in conflict
-with the version number of the new Minecraft version.
+### Version metadata
+
+The code doesn't contain version metadata: `build.gradle` specifies a version of `0.0.0`. The versioning information is
+entirely contained in Git by using tags.
+
+Per [Semantic Versioning](https://semver.org/spec/v2.0.0.html), the version number being released depends on the changes
+in that release. We usually can't predict those
+changes at the start of a release cycle, so we can't bump the version at the start of a release cycle. That means that
+the version number being released is determined at release time.
+
+Because the version number is determined at release time, we can't store any versioning metadata in the
+code (`build.gradle`). If we did, `build.gradle` would have the version number of the latest released version during the
+release cycle of the new version, which isn't correct.
+
+### Dealing with Minecraft
+
+Whenever we port to a new Minecraft version, at least the minor version should be incremented.
+
+This is needed so that we can still support older Minecraft versions without the Refined Storage version numbers
+conflicting.
 
 ## Changelog
 
@@ -113,16 +130,18 @@ coverage percentage of 90%.
 
 The release process is automated and follows Gitflow.
 
-Before running the "Draft release" workflow to start the release process:
+Before running the "Draft release" workflow to start the release process make sure `CHANGELOG.md` contains all the
+unreleased changes.
 
-- Make sure the version number in `build.gradle` is correct.
-- Make sure `CHANGELOG.md` contains all the unreleased changes.
+To determine the version number to be released, the workflow will ask you which release type this is (major, minor,
+patch).
+The latest version from `CHANGELOG.md` will be used as a base, and that will be incremented
+depending on the release type.
 
-The "Draft release" workflow will update the `CHANGELOG.md` and bump the version number in `build.gradle`.
-You can review these changes in the PR created by this workflow.
+`CHANGELOG.md` will be updated by this workflow, you can review this in the resulting release PR.
 
-If you merge the PR, the "Publish release" workflow will automatically publish the release. An additional PR will be
-created to merge the changes in `CHANGELOG.md` and `build.gradle` back into `develop`.
+If you merge the release PR, the "Publish release" workflow will automatically publish the release. An additional PR
+will be created to merge the changes in `CHANGELOG.md` back into `develop`.
 
 ## Hotfix process
 
@@ -175,13 +194,13 @@ The build workflow takes care of the following:
 
 The draft release workflow is a manual workflow which will create a release branch from `develop`.
 
-It will extract the version from `build.gradle` to know which version is being released.
+To determine the version number to be released, it will extract the latest version number from `CHANGELOG.md` and
+increment it depending on the release type selected.
 
 This workflow takes care of the following:
 
 - Creating the release branch.
 - Updating the changelog on this release branch.
-- Updating the version number in `build.gradle` to the next Semver version number on this release branch.
 - Creating a pull request merging the release branch into `main`.
 
 ### Publish release
@@ -191,7 +210,7 @@ in the draft release workflow.
 
 The workflow takes care of the following:
 
-- Extracting the version number from the release or hotfix branch that is merged in the PR.
+- Extracting the version number from the release or hotfix branch name that is merged in the PR.
 - Extracting the changelog entry for this version number.
 - Running a build.
 - Publishing on [GitHub packages](https://github.com/refinedmods/refinedstorage2/packages) and

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -205,8 +205,8 @@ This workflow takes care of the following:
 
 ### Publish release
 
-The "publish release" workflow is triggered when a PR is merged to `main`. Usually, this will be the PR created earlier
-in the draft release workflow.
+The "publish release" workflow is triggered when a release or hotfix PR is merged to `main`. Usually, this will be the
+PR created earlier in the "Draft release" workflow.
 
 The workflow takes care of the following:
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -2,8 +2,17 @@ name: Draft release
 on:
   workflow_dispatch:
     inputs:
-      next-version:
-        description: 'Next version number'
+      release-type:
+        description: 'Release type'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+      version-number:
+        description: 'Version number'
         required: false
 jobs:
   draft:
@@ -13,60 +22,47 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GITFLOW_PUSH_TOKEN }}
-      - name: Read build.gradle for version number
-        id: gradle
-        uses: juliangruber/read-file-action@v1
+      - name: Get latest version from changelog
+        if: "${{ github.event.inputs.version-number == '' }}"
+        id: changelog
+        uses: mindsers/changelog-reader-action@v2
         with:
-          path: build.gradle
-      - name: Extract version number from build.gradle
-        uses: actions-ecosystem/action-regex-match@v2
-        id: version
+          path: ./CHANGELOG.md
+      - name: Get version number to release (Semver)
+        if: "${{ github.event.inputs.version-number == '' }}"
+        uses: actions-ecosystem/action-bump-semver@v1
+        id: bump-semver
         with:
-          text: ${{ steps.gradle.outputs.content }}
-          regex: "version = \'(.*)\'"
+          current_version: ${{ steps.changelog.outputs.version }}
+          level: ${{ github.event.inputs.release-type }}
+      - name: Assign version number to release (Semver)
+        if: "${{ github.event.inputs.version-number == '' }}"
+        run: |
+          echo "VERSION=${{ steps.bump-semver.outputs.new_version }}" >> $GITHUB_ENV
+      - name: Assign version number to release (manual)
+        if: "${{ github.event.inputs.version-number != '' }}"
+        run: |
+          echo "VERSION=${{ github.event.inputs.version-number }}" >> $GITHUB_ENV
       - name: Update changelog
         uses: thomaseizinger/keep-a-changelog-new-release@1.1.0
         with:
-          version: ${{ steps.version.outputs.group1 }}
-      - name: Retrieve next version number
-        uses: actions-ecosystem/action-bump-semver@v1
-        if: "${{ github.event.inputs.next-version == '' }}"
-        id: bump-semver
-        with:
-          current_version: ${{ steps.version.outputs.group1 }}
-          level: minor
-      - name: Update version number (with Semver)
-        uses: jacobtomlinson/gha-find-replace@v2
-        if: "${{ github.event.inputs.next-version == '' }}"
-        with:
-          include: 'build.gradle'
-          find: ${{ steps.version.outputs.group1 }}
-          replace: ${{ steps.bump-semver.outputs.new_version }}
-          regex: false
-      - name: Update version number (manually)
-        uses: jacobtomlinson/gha-find-replace@v2
-        if: "${{ github.event.inputs.next-version != '' }}"
-        with:
-          include: 'build.gradle'
-          find: ${{ steps.version.outputs.group1 }}
-          replace: ${{ github.event.inputs.next-version }}
-          regex: false
+          version: ${{ env.VERSION }}
       - name: Commit and push changes
         uses: EndBug/add-and-commit@v9
         with:
-          add: '["CHANGELOG.md", "build.gradle"]'
+          add: 'CHANGELOG.md'
           default_author: github_actions
-          message: 'chore: prepare release v${{ steps.version.outputs.group1 }}'
-          new_branch: 'release/${{ steps.version.outputs.group1 }}'
+          message: 'chore: prepare release v${{ env.VERSION }}'
+          new_branch: 'release/${{ env.VERSION }}'
           push: true
       - name: Create pull request for release
         uses: thomaseizinger/create-pull-request@1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          head: release/${{ steps.version.outputs.group1 }}
+          head: release/${{ env.VERSION }}
           base: main
-          title: Release v${{ steps.version.outputs.group1 }}
+          title: Release v${{ env.VERSION }}
           reviewers: ${{ github.actor }}
           body: |
             Hi @${{ github.actor }}!

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,6 +9,8 @@ jobs:
   extract-version-number:
     name: Extract version number
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix/'))
     outputs:
       version: ${{ env.RELEASE_VERSION }}
     steps:
@@ -142,6 +144,8 @@ jobs:
   sync-develop:
     name: Sync develop
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix/'))
     steps:
       - name: Create PR for merging main back into develop
         uses: thomaseizinger/create-pull-request@1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,3 +264,25 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The Priority screen now has a "Reset" button.
 - The Grid can now use smooth scrolling.
 - The Grid now has syntax highlighting for the search query.
+
+[Unreleased]: https://github.com/refinedmods/refinedstorage2/compare/v2.0.0-milestone.2.4...HEAD
+
+[2.0.0-milestone.2.4]: https://github.com/refinedmods/refinedstorage2/compare/v2.0.0-milestone.2.3...v2.0.0-milestone.2.4
+
+[2.0.0-milestone.2.3]: https://github.com/refinedmods/refinedstorage2/compare/v2.0.0-milestone.2.2...v2.0.0-milestone.2.3
+
+[2.0.0-milestone.2.2]: https://github.com/refinedmods/refinedstorage2/compare/v2.0.0-milestone.2.1...v2.0.0-milestone.2.2
+
+[2.0.0-milestone.2.1]: https://github.com/refinedmods/refinedstorage2/compare/2.0.0-milestone.2.0...v2.0.0-milestone.2.1
+
+[2.0.0-milestone.2.0]: https://github.com/refinedmods/refinedstorage2/compare/v2.0.0-milestone.1.4...v2.0.0-milestone.2.0
+
+[2.0.0-milestone.1.4]: https://github.com/refinedmods/refinedstorage2/compare/v2.0.0-milestone.1.3...v2.0.0-milestone.1.4
+
+[2.0.0-milestone.1.3]: https://github.com/refinedmods/refinedstorage2/compare/v2.0.0-milestone.1.2...v2.0.0-milestone.1.3
+
+[2.0.0-milestone.1.2]: https://github.com/refinedmods/refinedstorage2/compare/v2.0.0-milestone.1.1...v2.0.0-milestone.1.2
+
+[2.0.0-milestone.1.1]: https://github.com/refinedmods/refinedstorage2/compare/2.0.0-milestone.1.0...v2.0.0-milestone.1.1
+
+[2.0.0-milestone.1.0]: https://github.com/raoulvdberge/refinedstorage2/releases/tag/v2.0.0-milestone.1.0

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ allprojects {
 
 subprojects {
     group = 'com.refinedmods.refinedstorage2'
-    version = '2.0.0-milestone.2.5'
+    version = '0.0.0'
 
     if (System.getenv('GITHUB_SHA') != null) {
         version += '+' + System.getenv('GITHUB_SHA').substring(0, 7)


### PR DESCRIPTION
Per Semver, the version number being released depends on the changes in that release.

We can't predict those
changes at the start of a release cycle,
 so we can't bump the version at the start of a release cycle.

That means that the version number being released is determined at release time.

Because the version number is determined at release time, we can't store any versioning metadata in the code.

If we did, build.gradle would have the version number of the latest released version during the release cycle of the new version, which isn't correct.
