### PR TITLE
ci: add automated locking of resolved issues and PRs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -189,6 +189,7 @@ We have a few GitHub workflows:
 - Validate branch names (PRs)
 - Issue for unsupported version (issues)
     - Posts a message on a GitHub issue if the issue is about an unsupported version.
+- Lock resolved issues and PRs (every night)
 
 ### Build
 

--- a/.github/workflows/resolved-issue-locking.yml
+++ b/.github/workflows/resolved-issue-locking.yml
@@ -1,0 +1,13 @@
+name: Lock resolved issues and PRs
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: '30'
+          pr-lock-inactive-days: '30'


### PR DESCRIPTION
To avoid people posting on old issues instead of creating a new issue.

Closes #288 