### PR TITLE
build: expose api guardian as part of API

### DIFF
--- a/refinedstorage2-core-api/build.gradle
+++ b/refinedstorage2-core-api/build.gradle
@@ -1,7 +1,11 @@
+plugins {
+    id 'java-library'
+}
+
 archivesBaseName = 'refinedstorage2-core-api'
 
 dependencies {
-    implementation libs.apiguardian
+    api libs.apiguardian
     testImplementation testLibs.junit.api
     testImplementation testLibs.junit.params
     testRuntimeOnly testLibs.junit.engine

--- a/refinedstorage2-grid-api/build.gradle
+++ b/refinedstorage2-grid-api/build.gradle
@@ -1,7 +1,11 @@
+plugins {
+    id 'java-library'
+}
+
 archivesBaseName = 'refinedstorage2-grid-api'
 
 dependencies {
-    implementation libs.apiguardian
+    api libs.apiguardian
     implementation libs.slf4j.api
     testImplementation testLibs.junit.api
     testImplementation testLibs.junit.params

--- a/refinedstorage2-network-api/build.gradle
+++ b/refinedstorage2-network-api/build.gradle
@@ -1,7 +1,11 @@
+plugins {
+    id 'java-library'
+}
+
 archivesBaseName = 'refinedstorage2-network-api'
 
 dependencies {
-    implementation libs.apiguardian
+    api libs.apiguardian
     implementation project(':refinedstorage2-core-api')
     implementation project(':refinedstorage2-resource-api')
     implementation project(':refinedstorage2-storage-api')

--- a/refinedstorage2-network/build.gradle
+++ b/refinedstorage2-network/build.gradle
@@ -2,7 +2,6 @@ archivesBaseName = 'refinedstorage2-network'
 
 dependencies {
     implementation libs.slf4j.api
-    implementation libs.apiguardian
     testRuntimeOnly libs.slf4j.impl
     testImplementation testLibs.junit.api
     testImplementation testLibs.junit.params

--- a/refinedstorage2-platform-api/build.gradle
+++ b/refinedstorage2-platform-api/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'java-library'
     alias(libs.plugins.mixin)
 }
 
@@ -17,8 +18,7 @@ minecraft {
 }
 
 dependencies {
-    compileOnly libs.mixin
-    implementation libs.apiguardian
+    api libs.apiguardian
     implementation project(':refinedstorage2-core-api')
     implementation project(':refinedstorage2-storage-api')
     implementation project(':refinedstorage2-resource-api')

--- a/refinedstorage2-platform-common/build.gradle
+++ b/refinedstorage2-platform-common/build.gradle
@@ -22,7 +22,6 @@ sourceSets {
 
 dependencies {
     compileOnly libs.mixin
-    implementation libs.apiguardian // mandatory as we import it from platform-api
     implementation libs.jei.common.api
     implementation project(':refinedstorage2-platform-api')
     implementation project(':refinedstorage2-core-api')

--- a/refinedstorage2-platform-fabric/build.gradle
+++ b/refinedstorage2-platform-fabric/build.gradle
@@ -50,8 +50,6 @@ dependencies {
         implementation project(it)
     }
 
-    implementation libs.apiguardian // mandatory as it's imported through platform-api
-
     modImplementation(fabric.cloth.config) {
         exclude(group: 'net.fabricmc.fabric-api')
     }
@@ -62,21 +60,20 @@ dependencies {
     }
     include fabric.teamreborn.energy
 
-    modCompileOnly(fabric.rei.api) {
-        exclude(group: 'me.shedaniel.cloth')
-    }
-    // We test with REI on Fabric.
-    modRuntimeOnly fabric.bundles.rei.runtime
-
-    modImplementation fabric.jei.common.api
-//    modRuntimeOnly fabric.jei.fabric.impl
+    modImplementation fabric.noIndium
+    include fabric.noIndium
 
     modImplementation fabric.modmenu
 
-    modRuntimeOnly fabric.wthit
+    modCompileOnly(fabric.rei.api) {
+        exclude(group: 'me.shedaniel.cloth')
+    }
+    modRuntimeOnly fabric.bundles.rei.runtime
 
-    modImplementation fabric.noIndium
-    include fabric.noIndium
+    modCompileOnly fabric.jei.common.api
+    // modRuntimeOnly fabric.jei.fabric.impl
+
+    modRuntimeOnly fabric.wthit
 }
 
 loom {

--- a/refinedstorage2-platform-forge/build.gradle
+++ b/refinedstorage2-platform-forge/build.gradle
@@ -76,12 +76,9 @@ dependencies {
         implementation project(it)
     }
 
-    implementation libs.apiguardian // mandatory as it's imported through platform-api
-
     compileOnly fg.deobf(forge.jei.common.api.get())
     testCompileOnly fg.deobf(forge.jei.common.api.get())
     compileOnly fg.deobf(forge.jei.forge.api.get())
-    // We test with JEI on Forge.
     runtimeOnly fg.deobf(forge.jei.forge.impl.get())
 
     compileOnly fg.deobf(forge.rei.forge.get())

--- a/refinedstorage2-resource-api/build.gradle
+++ b/refinedstorage2-resource-api/build.gradle
@@ -1,7 +1,11 @@
+plugins {
+    id 'java-library'
+}
+
 archivesBaseName = 'refinedstorage2-resource-api'
 
 dependencies {
-    implementation libs.apiguardian
+    api libs.apiguardian
     testImplementation testLibs.junit.api
     testRuntimeOnly testLibs.junit.engine
     testImplementation testLibs.assertJ

--- a/refinedstorage2-storage-api/build.gradle
+++ b/refinedstorage2-storage-api/build.gradle
@@ -1,7 +1,11 @@
+plugins {
+    id 'java-library'
+}
+
 archivesBaseName = 'refinedstorage2-storage-api'
 
 dependencies {
-    implementation libs.apiguardian
+    api libs.apiguardian
     implementation libs.slf4j.api
     testImplementation testLibs.junit.api
     testImplementation testLibs.junit.params


### PR DESCRIPTION
This avoids the need for end users to include API Guardian again.