### PR TITLE
refactor: suppress false positive redundant suppression warnings

### DIFF
--- a/refinedstorage2-platform-api/src/main/java/com/refinedmods/refinedstorage2/platform/api/resource/FluidResource.java
+++ b/refinedstorage2-platform-api/src/main/java/com/refinedmods/refinedstorage2/platform/api/resource/FluidResource.java
@@ -29,7 +29,7 @@ public record FluidResource(Fluid fluid, @Nullable CompoundTag tag) implements F
         return new FluidResource(fluid, null);
     }
 
-    @SuppressWarnings("deprecation") // forge deprecates Registry access
+    @SuppressWarnings({"deprecation", "RedundantSuppression"}) // forge deprecates Registry access
     public static CompoundTag toTag(final FluidResource fluidResource) {
         final CompoundTag tag = new CompoundTag();
         if (fluidResource.tag() != null) {
@@ -45,7 +45,7 @@ public record FluidResource(Fluid fluid, @Nullable CompoundTag tag) implements F
         return tag;
     }
 
-    @SuppressWarnings("deprecation") // forge deprecates Registry access
+    @SuppressWarnings({"deprecation", "RedundantSuppression"}) // forge deprecates Registry access
     public static Optional<FluidResource> fromTag(final CompoundTag tag) {
         final ResourceLocation id = new ResourceLocation(tag.getString(TAG_ID));
         final Fluid fluid = BuiltInRegistries.FLUID.get(id);

--- a/refinedstorage2-platform-api/src/main/java/com/refinedmods/refinedstorage2/platform/api/resource/ItemResource.java
+++ b/refinedstorage2-platform-api/src/main/java/com/refinedmods/refinedstorage2/platform/api/resource/ItemResource.java
@@ -54,7 +54,7 @@ public record ItemResource(Item item, @Nullable CompoundTag tag) implements Fuzz
         return new ItemResource(itemStack.getItem(), itemStack.getTag());
     }
 
-    @SuppressWarnings("deprecation") // forge deprecates Registry access
+    @SuppressWarnings({"deprecation", "RedundantSuppression"}) // forge deprecates Registry access
     public static CompoundTag toTag(final ItemResource itemResource) {
         final CompoundTag tag = new CompoundTag();
         if (itemResource.tag() != null) {
@@ -70,7 +70,7 @@ public record ItemResource(Item item, @Nullable CompoundTag tag) implements Fuzz
         return tag;
     }
 
-    @SuppressWarnings("deprecation") // forge deprecates Registry access
+    @SuppressWarnings({"deprecation", "RedundantSuppression"}) // forge deprecates Registry access
     public static Optional<ItemResource> fromTag(final CompoundTag tag) {
         final ResourceLocation id = new ResourceLocation(tag.getString(TAG_ID));
         final Item item = BuiltInRegistries.ITEM.get(id);

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/grid/PlatformGridServiceFactoryImpl.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/grid/PlatformGridServiceFactoryImpl.java
@@ -28,7 +28,7 @@ public class PlatformGridServiceFactoryImpl implements PlatformGridServiceFactor
     }
 
     @Override
-    @SuppressWarnings("deprecation") // forge deprecates stack insensitive getMaxStackSize
+    @SuppressWarnings({"deprecation", "RedundantSuppression"}) // forge deprecates stack insensitive getMaxStackSize
     public GridService<ItemResource> createForItem(final Actor actor) {
         return create(
             StorageChannelTypes.ITEM,

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/grid/view/AbstractFluidGridResourceFactory.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/grid/view/AbstractFluidGridResourceFactory.java
@@ -35,7 +35,7 @@ public abstract class AbstractFluidGridResourceFactory implements GridResourceFa
         ));
     }
 
-    @SuppressWarnings("deprecation") // forge deprecates Registry access
+    @SuppressWarnings({"deprecation", "RedundantSuppression"}) // forge deprecates Registry access
     private Set<String> getTags(final Fluid fluid) {
         return BuiltInRegistries.FLUID.getResourceKey(fluid)
             .flatMap(BuiltInRegistries.FLUID::getHolder)
@@ -45,7 +45,7 @@ public abstract class AbstractFluidGridResourceFactory implements GridResourceFa
             .collect(Collectors.toSet());
     }
 
-    @SuppressWarnings("deprecation") // forge deprecates Registry access
+    @SuppressWarnings({"deprecation", "RedundantSuppression"}) // forge deprecates Registry access
     private String getModId(final FluidResource fluid) {
         return BuiltInRegistries.FLUID.getKey(fluid.fluid()).getNamespace();
     }

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/grid/view/AbstractItemGridResourceFactory.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/grid/view/AbstractItemGridResourceFactory.java
@@ -49,7 +49,7 @@ public abstract class AbstractItemGridResourceFactory implements GridResourceFac
             .collect(Collectors.joining("\n"));
     }
 
-    @SuppressWarnings("deprecation") // forge deprecates Registry access
+    @SuppressWarnings({"deprecation", "RedundantSuppression"}) // forge deprecates Registry access
     private Set<String> getTags(final Item item) {
         return BuiltInRegistries.ITEM.getResourceKey(item)
             .flatMap(BuiltInRegistries.ITEM::getHolder)

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/grid/view/FluidGridResource.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/grid/view/FluidGridResource.java
@@ -22,7 +22,7 @@ public class FluidGridResource extends AbstractGridResource<FluidResource> {
     private final FluidResource fluidResource;
     private final int id;
 
-    @SuppressWarnings("deprecation") // forge deprecates Registry access
+    @SuppressWarnings({"deprecation", "RedundantSuppression"}) // forge deprecates Registry access
     public FluidGridResource(final ResourceAmount<FluidResource> resourceAmount,
                              final String name,
                              final String modId,

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/util/PacketUtil.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/util/PacketUtil.java
@@ -26,13 +26,13 @@ public final class PacketUtil {
         return new ItemResource(Item.byId(id), nbt);
     }
 
-    @SuppressWarnings("deprecation") // forge deprecates Registry access
+    @SuppressWarnings({"deprecation", "RedundantSuppression"}) // forge deprecates Registry access
     public static void writeFluidResource(final FriendlyByteBuf buf, final FluidResource itemResource) {
         buf.writeVarInt(BuiltInRegistries.FLUID.getId(itemResource.fluid()));
         buf.writeNbt(itemResource.tag());
     }
 
-    @SuppressWarnings("deprecation") // forge deprecates Registry access
+    @SuppressWarnings({"deprecation", "RedundantSuppression"}) // forge deprecates Registry access
     public static FluidResource readFluidResource(final FriendlyByteBuf buf) {
         final int id = buf.readVarInt();
         final CompoundTag nbt = buf.readNbt();


### PR DESCRIPTION
refactoring according to #328

This one superseeds #329, since branch renaming invalidates a Pr.