### PR TITLE
fix: disk drives have 8 slots for putting in disks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed Disk Drive having 9 slots instead of 8.
+
 ### Added
 
 -  The upgrade slots now show their supported upgrades.

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/block/entity/diskdrive/AbstractDiskDriveBlockEntity.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/block/entity/diskdrive/AbstractDiskDriveBlockEntity.java
@@ -50,9 +50,9 @@ import static com.refinedmods.refinedstorage2.platform.common.util.IdentifierUti
 public abstract class AbstractDiskDriveBlockEntity
     extends AbstractInternalNetworkNodeContainerBlockEntity<MultiStorageNetworkNode>
     implements BlockEntityWithDrops, MultiStorageListener, ExtendedMenuProvider {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDiskDriveBlockEntity.class);
+    public static final int AMOUNT_OF_DISKS = 8;
 
-    private static final int AMOUNT_OF_DISKS = 9;
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDiskDriveBlockEntity.class);
 
     private static final String TAG_DISK_INVENTORY = "inv";
     private static final String TAG_STATES = "states";

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/containermenu/storage/diskdrive/DiskDriveContainerMenu.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/containermenu/storage/diskdrive/DiskDriveContainerMenu.java
@@ -3,6 +3,7 @@ package com.refinedmods.refinedstorage2.platform.common.containermenu.storage.di
 import com.refinedmods.refinedstorage2.api.storage.StorageInfo;
 import com.refinedmods.refinedstorage2.platform.api.PlatformApi;
 import com.refinedmods.refinedstorage2.platform.api.item.StorageContainerItem;
+import com.refinedmods.refinedstorage2.platform.common.block.entity.diskdrive.AbstractDiskDriveBlockEntity;
 import com.refinedmods.refinedstorage2.platform.common.containermenu.slot.ResourceFilterSlot;
 import com.refinedmods.refinedstorage2.platform.common.containermenu.slot.ValidatedSlot;
 import com.refinedmods.refinedstorage2.platform.common.containermenu.storage.AbstractStorageContainerMenu;
@@ -39,7 +40,11 @@ public class DiskDriveContainerMenu extends AbstractStorageContainerMenu impleme
         this.storageInfoAccessor = new StorageDiskInfoAccessorImpl(PlatformApi.INSTANCE.getStorageRepository(
             playerInventory.player.getLevel()
         ));
-        addSlots(playerInventory.player, new SimpleContainer(9), new ResourceFilterContainer(9));
+        addSlots(
+            playerInventory.player,
+            new SimpleContainer(AbstractDiskDriveBlockEntity.AMOUNT_OF_DISKS),
+            new ResourceFilterContainer(9)
+        );
         initializeResourceFilterSlots(buf);
     }
 


### PR DESCRIPTION
correct #327

superseeds #330, since branch renaming for the branch that should go into another does not work.