### PR TITLE
fix: external storage crash on Fabric when a stack with zero amount is exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed filter slot hints not being aware of the resource types that they can show in a slot.
 - Fixed Exporter only exporting 1 mB per cycle on Forge.
 - Fixed not being able to use any blocks on Fabric or Forge.
+- Fixed External Storage crash on Fabric when a stack with zero amount is exposed.
 
 ## [2.0.0-milestone.2.12] - 2023-08-06
 

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/grid/view/FluidGridResource.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/internal/grid/view/FluidGridResource.java
@@ -52,7 +52,7 @@ public class FluidGridResource extends AbstractGridResource<FluidResource> {
     public List<? extends ClientTooltipComponent> getExtractionHints() {
         return Platform.INSTANCE.convertToBucket(fluidResource).map(
             bucket -> new MouseWithIconClientTooltipComponent(
-                MouseWithIconClientTooltipComponent.Type.RIGHT,
+                MouseWithIconClientTooltipComponent.Type.LEFT,
                 (graphics, x, y) -> graphics.renderItem(bucket, x, y),
                 null
             )

--- a/refinedstorage2-platform-fabric/src/main/java/com/refinedmods/refinedstorage2/platform/fabric/internal/network/node/externalstorage/StorageExternalStorageProvider.java
+++ b/refinedstorage2-platform-fabric/src/main/java/com/refinedmods/refinedstorage2/platform/fabric/internal/network/node/externalstorage/StorageExternalStorageProvider.java
@@ -75,7 +75,7 @@ public class StorageExternalStorageProvider<T, P> implements ExternalStorageProv
         }
         final Iterator<StorageView<P>> iterator = storage.iterator();
         return transform(
-            filter(iterator, storageView -> !storageView.isResourceBlank()),
+            filter(iterator, storageView -> !storageView.isResourceBlank() && storageView.getAmount() > 0),
             storageView -> new ResourceAmount<>(
                 fromPlatformMapper.apply(storageView.getResource()),
                 storageView.getAmount()


### PR DESCRIPTION
Fixes #386 