### PR TITLE
refactor: bind energy storage to controller item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+-  You can now recharge the Controller in item form.
+
 ### Removed
 
 -   The `useEnergy` config option for the Wireless Grid. If you do not wish to use energy, use the

--- a/refinedstorage2-platform-api/src/main/java/com/refinedmods/refinedstorage2/platform/api/item/AbstractEnergyBlockItem.java
+++ b/refinedstorage2-platform-api/src/main/java/com/refinedmods/refinedstorage2/platform/api/item/AbstractEnergyBlockItem.java
@@ -1,0 +1,78 @@
+package com.refinedmods.refinedstorage2.platform.api.item;
+
+import com.refinedmods.refinedstorage2.api.core.Action;
+import com.refinedmods.refinedstorage2.platform.api.PlatformApi;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.Mth;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+
+public abstract class AbstractEnergyBlockItem extends BlockItem implements EnergyItem {
+    protected AbstractEnergyBlockItem(final Block block, final Properties properties) {
+        super(block, properties);
+    }
+
+    @Override
+    public void appendHoverText(
+        final ItemStack stack,
+        @Nullable final Level level,
+        final List<Component> lines,
+        final TooltipFlag flag
+    ) {
+        super.appendHoverText(stack, level, lines, flag);
+        PlatformApi.INSTANCE.getEnergyStorage(stack).ifPresent(energyStorage -> {
+            final long stored = energyStorage.getStored();
+            final long capacity = energyStorage.getCapacity();
+            final double pct = stored / (double) capacity;
+            lines.add(PlatformApi.INSTANCE.createStoredWithCapacityTranslation(stored, capacity, pct)
+                .withStyle(ChatFormatting.GRAY));
+        });
+    }
+
+    @Override
+    public boolean isBarVisible(final ItemStack stack) {
+        return PlatformApi.INSTANCE.getEnergyStorage(stack).isPresent();
+    }
+
+    @Override
+    public int getBarWidth(final ItemStack stack) {
+        return PlatformApi.INSTANCE.getEnergyStorage(stack).map(energyStorage -> (int) Math.round(
+            (energyStorage.getStored() / (double) energyStorage.getCapacity()) * 13D
+        )).orElse(0);
+    }
+
+    @Override
+    public int getBarColor(final ItemStack stack) {
+        return PlatformApi.INSTANCE.getEnergyStorage(stack).map(energyStorage -> Mth.hsvToRgb(
+            Math.max(0.0F, (float) energyStorage.getStored() / (float) energyStorage.getCapacity()) / 3.0F,
+            1.0F,
+            1.0F
+        )).orElse(0);
+    }
+
+    public ItemStack createAtEnergyCapacity() {
+        final ItemStack stack = new ItemStack(this);
+        PlatformApi.INSTANCE.getEnergyStorage(stack).ifPresent(energyStorage -> energyStorage.receive(
+            energyStorage.getCapacity(),
+            Action.EXECUTE
+        ));
+        return stack;
+    }
+
+    public static Stream<ItemStack> createAllAtEnergyCapacity(final List<Supplier<BlockItem>> items) {
+        return items.stream().map(Supplier::get)
+            .filter(AbstractEnergyBlockItem.class::isInstance)
+            .map(AbstractEnergyBlockItem.class::cast)
+            .map(AbstractEnergyBlockItem::createAtEnergyCapacity);
+    }
+}

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/black_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/black_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/blue_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/blue_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/brown_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/brown_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/cyan_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/cyan_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/gray_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/gray_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/green_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/green_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/light_gray_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/light_gray_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/lime_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/lime_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/magenta_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/magenta_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/orange_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/orange_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/pink_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/pink_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/purple_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/purple_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/red_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/red_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/white_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/white_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/yellow_controller.json
+++ b/refinedstorage2-platform-common/src/generated/resources/data/refinedstorage2/loot_tables/blocks/yellow_controller.json
@@ -1,4 +1,9 @@
 {
+  "functions": [
+    {
+      "function": "refinedstorage2:energy"
+    }
+  ],
   "pools": [
     {
       "bonus_rolls": 0.0,

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/AbstractModInitializer.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/AbstractModInitializer.java
@@ -7,7 +7,6 @@ import com.refinedmods.refinedstorage2.api.network.impl.component.GraphNetworkCo
 import com.refinedmods.refinedstorage2.api.network.impl.component.StorageNetworkComponentImpl;
 import com.refinedmods.refinedstorage2.platform.api.PlatformApi;
 import com.refinedmods.refinedstorage2.platform.api.PlatformApiProxy;
-import com.refinedmods.refinedstorage2.platform.common.block.AbstractStorageBlock;
 import com.refinedmods.refinedstorage2.platform.common.block.ControllerType;
 import com.refinedmods.refinedstorage2.platform.common.block.DiskDriveBlock;
 import com.refinedmods.refinedstorage2.platform.common.block.FluidStorageBlock;
@@ -84,6 +83,8 @@ import com.refinedmods.refinedstorage2.platform.common.item.WrenchItem;
 import com.refinedmods.refinedstorage2.platform.common.item.block.FluidStorageBlockBlockItem;
 import com.refinedmods.refinedstorage2.platform.common.item.block.ItemStorageBlockBlockItem;
 import com.refinedmods.refinedstorage2.platform.common.item.block.SimpleBlockItem;
+import com.refinedmods.refinedstorage2.platform.common.loot.EnergyLootItemFunctionSerializer;
+import com.refinedmods.refinedstorage2.platform.common.loot.StorageBlockLootItemFunctionSerializer;
 import com.refinedmods.refinedstorage2.platform.common.recipe.UpgradeWithEnchantedBookRecipeSerializer;
 
 import java.util.Optional;
@@ -603,7 +604,11 @@ public abstract class AbstractModInitializer {
     protected final void registerLootFunctions(final RegistryCallback<LootItemFunctionType> callback) {
         LootFunctions.INSTANCE.setStorageBlock(callback.register(
             STORAGE_BLOCK,
-            () -> new LootItemFunctionType(new AbstractStorageBlock.StorageBlockLootItemFunctionSerializer())
+            () -> new LootItemFunctionType(new StorageBlockLootItemFunctionSerializer())
+        ));
+        LootFunctions.INSTANCE.setEnergy(callback.register(
+            createIdentifier("energy"),
+            () -> new LootItemFunctionType(new EnergyLootItemFunctionSerializer())
         ));
     }
 

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/block/AbstractStorageBlock.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/block/AbstractStorageBlock.java
@@ -1,36 +1,19 @@
 package com.refinedmods.refinedstorage2.platform.common.block;
 
-import com.refinedmods.refinedstorage2.platform.api.PlatformApi;
 import com.refinedmods.refinedstorage2.platform.common.block.entity.storage.AbstractStorageBlockBlockEntity;
 import com.refinedmods.refinedstorage2.platform.common.block.ticker.AbstractBlockEntityTicker;
-import com.refinedmods.refinedstorage2.platform.common.content.LootFunctions;
 
-import java.util.UUID;
 import javax.annotation.Nullable;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSerializationContext;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.EntityBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.storage.loot.Serializer;
-import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
-import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
-import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public abstract class AbstractStorageBlock<T extends AbstractStorageBlockBlockEntity<?>>
-    extends AbstractBaseBlock
+public abstract class AbstractStorageBlock<T extends AbstractStorageBlockBlockEntity<?>> extends AbstractBaseBlock
     implements EntityBlock {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractStorageBlock.class);
-
     private final AbstractBlockEntityTicker<T> ticker;
 
     protected AbstractStorageBlock(final Properties properties, final AbstractBlockEntityTicker<T> ticker) {
@@ -44,46 +27,5 @@ public abstract class AbstractStorageBlock<T extends AbstractStorageBlockBlockEn
                                                                   final BlockState blockState,
                                                                   final BlockEntityType<O> type) {
         return ticker.get(level, type);
-    }
-
-    public static class StorageBlockLootItemFunction implements LootItemFunction {
-        @Override
-        public LootItemFunctionType getType() {
-            return LootFunctions.INSTANCE.getStorageBlock();
-        }
-
-        @Override
-        public ItemStack apply(final ItemStack stack, final LootContext lootContext) {
-            final BlockEntity blockEntity = lootContext.getParam(LootContextParams.BLOCK_ENTITY);
-            if (blockEntity instanceof AbstractStorageBlockBlockEntity<?> storageBlockEntity) {
-                apply(stack, storageBlockEntity);
-            }
-            return stack;
-        }
-
-        private void apply(final ItemStack stack, final AbstractStorageBlockBlockEntity<?> storageBlockEntity) {
-            final UUID storageId = storageBlockEntity.getStorageId();
-            if (storageId != null) {
-                LOGGER.debug("Transferred storage {} at {} to stack", storageId, storageBlockEntity.getBlockPos());
-                PlatformApi.INSTANCE.getStorageContainerItemHelper().setId(stack, storageId);
-            } else {
-                LOGGER.warn("Storage block {} has no associated storage ID!", storageBlockEntity.getBlockPos());
-            }
-        }
-    }
-
-    public static class StorageBlockLootItemFunctionSerializer implements Serializer<LootItemFunction> {
-        @Override
-        public void serialize(final JsonObject jsonObject,
-                              final LootItemFunction lootItemFunction,
-                              final JsonSerializationContext jsonSerializationContext) {
-            // nothing to do
-        }
-
-        @Override
-        public LootItemFunction deserialize(final JsonObject jsonObject,
-                                            final JsonDeserializationContext jsonDeserializationContext) {
-            return new StorageBlockLootItemFunction();
-        }
     }
 }

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/block/entity/ControllerBlockEntity.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/block/entity/ControllerBlockEntity.java
@@ -13,8 +13,6 @@ import com.refinedmods.refinedstorage2.platform.common.content.BlockEntities;
 import com.refinedmods.refinedstorage2.platform.common.internal.energy.CreativeEnergyStorage;
 import com.refinedmods.refinedstorage2.platform.common.menu.ExtendedMenuProvider;
 
-import javax.annotation.Nullable;
-
 import com.google.common.util.concurrent.RateLimiter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -66,26 +64,6 @@ public class ControllerBlockEntity extends AbstractInternalNetworkNodeContainerB
             : BlockEntities.INSTANCE.getController();
     }
 
-    public static long getStored(final CompoundTag tag) {
-        return tag.contains(TAG_STORED) ? tag.getLong(TAG_STORED) : 0;
-    }
-
-    public static void setStored(final CompoundTag tag, final long stored) {
-        tag.putLong(TAG_STORED, stored);
-    }
-
-    public static long getCapacity(final CompoundTag tag) {
-        return tag.contains(TAG_CAPACITY) ? tag.getLong(TAG_CAPACITY) : 0;
-    }
-
-    public static void setCapacity(final CompoundTag tag, final long capacity) {
-        tag.putLong(TAG_CAPACITY, capacity);
-    }
-
-    public static boolean hasEnergy(@Nullable final CompoundTag tag) {
-        return tag != null && tag.contains(TAG_STORED) && tag.contains(TAG_CAPACITY);
-    }
-
     public void updateEnergyTypeInLevel(final BlockState state) {
         final ControllerEnergyType currentEnergyType = ControllerEnergyType.ofState(getNode().getState());
         final ControllerEnergyType inLevelEnergyType = state.getValue(ControllerBlock.ENERGY_TYPE);
@@ -122,7 +100,7 @@ public class ControllerBlockEntity extends AbstractInternalNetworkNodeContainerB
     public void load(final CompoundTag tag) {
         super.load(tag);
         if (tag.contains(TAG_STORED)) {
-            energyStorage.receive(tag.getLong(TAG_STORED), Action.EXECUTE);
+            loadEnergy(tag.getLong(TAG_STORED));
         }
     }
 
@@ -156,5 +134,9 @@ public class ControllerBlockEntity extends AbstractInternalNetworkNodeContainerB
     @Override
     public EnergyStorage getEnergyStorage() {
         return energyStorage;
+    }
+
+    public void loadEnergy(final long stored) {
+        energyStorage.receive(stored, Action.EXECUTE);
     }
 }

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/content/CreativeModeTabItems.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/content/CreativeModeTabItems.java
@@ -1,9 +1,9 @@
 package com.refinedmods.refinedstorage2.platform.common.content;
 
+import com.refinedmods.refinedstorage2.platform.api.item.AbstractEnergyBlockItem;
 import com.refinedmods.refinedstorage2.platform.common.internal.storage.type.FluidStorageType;
 import com.refinedmods.refinedstorage2.platform.common.internal.storage.type.ItemStorageType;
 import com.refinedmods.refinedstorage2.platform.common.item.ProcessorItem;
-import com.refinedmods.refinedstorage2.platform.common.item.block.ControllerBlockItem;
 
 import java.util.Arrays;
 import java.util.function.Consumer;
@@ -24,7 +24,7 @@ public final class CreativeModeTabItems {
     private static void appendBlocks(final Consumer<ItemStack> consumer) {
         final Consumer<ItemLike> itemConsumer = item -> consumer.accept(new ItemStack(item));
         Items.INSTANCE.getControllers().stream().map(Supplier::get).forEach(itemConsumer);
-        ControllerBlockItem.getAllAtCapacity().forEach(consumer);
+        AbstractEnergyBlockItem.createAllAtEnergyCapacity(Items.INSTANCE.getControllers()).forEach(consumer);
         Items.INSTANCE.getCreativeControllers().stream().map(Supplier::get).forEach(itemConsumer);
         Items.INSTANCE.getCables().stream().map(Supplier::get).forEach(itemConsumer);
         Items.INSTANCE.getImporters().stream().map(Supplier::get).forEach(itemConsumer);

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/content/LootFunctions.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/content/LootFunctions.java
@@ -11,6 +11,8 @@ public final class LootFunctions {
 
     @Nullable
     private Supplier<LootItemFunctionType> storageBlock;
+    @Nullable
+    private Supplier<LootItemFunctionType> energy;
 
     private LootFunctions() {
     }
@@ -19,7 +21,15 @@ public final class LootFunctions {
         return Objects.requireNonNull(storageBlock).get();
     }
 
-    public void setStorageBlock(final Supplier<LootItemFunctionType> storageBlockSupplier) {
-        this.storageBlock = storageBlockSupplier;
+    public void setStorageBlock(final Supplier<LootItemFunctionType> supplier) {
+        this.storageBlock = supplier;
+    }
+
+    public LootItemFunctionType getEnergy() {
+        return Objects.requireNonNull(energy).get();
+    }
+
+    public void setEnergy(final Supplier<LootItemFunctionType> supplier) {
+        this.energy = supplier;
     }
 }

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/item/block/ControllerBlockItem.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/item/block/ControllerBlockItem.java
@@ -1,66 +1,45 @@
 package com.refinedmods.refinedstorage2.platform.common.item.block;
 
+import com.refinedmods.refinedstorage2.api.network.energy.EnergyStorage;
+import com.refinedmods.refinedstorage2.api.network.impl.energy.EnergyStorageImpl;
+import com.refinedmods.refinedstorage2.platform.api.PlatformApi;
+import com.refinedmods.refinedstorage2.platform.api.item.AbstractEnergyBlockItem;
 import com.refinedmods.refinedstorage2.platform.api.item.HelpTooltipComponent;
 import com.refinedmods.refinedstorage2.platform.common.Platform;
 import com.refinedmods.refinedstorage2.platform.common.block.entity.ControllerBlockEntity;
-import com.refinedmods.refinedstorage2.platform.common.content.BlockEntities;
-import com.refinedmods.refinedstorage2.platform.common.content.Items;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
-import net.minecraft.ChatFormatting;
-import net.minecraft.nbt.CompoundTag;
+import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import net.minecraft.util.Mth;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 
-import static com.refinedmods.refinedstorage2.platform.common.util.IdentifierUtil.createStoredWithCapacityTranslation;
 import static com.refinedmods.refinedstorage2.platform.common.util.IdentifierUtil.createTranslation;
 
-// TODO: Use cap here.
 // TODO: Make network bound item api accessible.
-public class ControllerBlockItem extends CreativeControllerBlockItem {
+public class ControllerBlockItem extends AbstractEnergyBlockItem {
+    private final Component name;
+
     public ControllerBlockItem(final Block block, final Component displayName) {
-        super(block, displayName);
+        super(block, new Item.Properties().stacksTo(1));
+        this.name = displayName;
     }
 
-    public static float getPercentFull(final ItemStack stack) {
-        final CompoundTag tag = getBlockEntityData(stack);
-        if (tag == null) {
-            return 1;
-        }
-        final long stored = ControllerBlockEntity.getStored(tag);
-        final long capacity = ControllerBlockEntity.getCapacity(tag);
-        if (capacity == 0) {
-            return 1;
-        }
-        return (float) stored / (float) capacity;
+    @Override
+    public Component getDescription() {
+        return name;
     }
 
-    public ItemStack getAtCapacity() {
-        final long capacity = Platform.INSTANCE.getConfig().getController().getEnergyCapacity();
-        final ItemStack result = new ItemStack(this);
-        final CompoundTag blockEntityData = new CompoundTag();
-        ControllerBlockEntity.setStored(blockEntityData, capacity);
-        ControllerBlockEntity.setCapacity(blockEntityData, capacity);
-        setBlockEntityData(result, BlockEntities.INSTANCE.getController(), blockEntityData);
-        return result;
-    }
-
-    public static Stream<ItemStack> getAllAtCapacity() {
-        return Items.INSTANCE.getControllers().stream()
-            .map(Supplier::get)
-            .filter(ControllerBlockItem.class::isInstance)
-            .map(ControllerBlockItem.class::cast)
-            .map(ControllerBlockItem::getAtCapacity);
+    @Override
+    public Component getName(final ItemStack stack) {
+        return name;
     }
 
     @Override
@@ -69,32 +48,27 @@ public class ControllerBlockItem extends CreativeControllerBlockItem {
     }
 
     @Override
-    public boolean isBarVisible(final ItemStack stack) {
-        return ControllerBlockEntity.hasEnergy(getBlockEntityData(stack));
+    public Optional<EnergyStorage> createEnergyStorage(final ItemStack stack) {
+        final EnergyStorage energyStorage = new EnergyStorageImpl(
+            Platform.INSTANCE.getConfig().getController().getEnergyCapacity()
+        );
+        return Optional.of(PlatformApi.INSTANCE.asItemEnergyStorage(energyStorage, stack));
     }
 
     @Override
-    public int getBarWidth(final ItemStack stack) {
-        return Math.round(getPercentFull(stack) * 13F);
-    }
-
-    @Override
-    public int getBarColor(final ItemStack stack) {
-        return Mth.hsvToRgb(Math.max(0.0F, getPercentFull(stack)) / 3.0F, 1.0F, 1.0F);
-    }
-
-    @Override
-    public void appendHoverText(final ItemStack stack,
-                                @Nullable final Level level,
-                                final List<Component> tooltip,
-                                final TooltipFlag context) {
-        super.appendHoverText(stack, level, tooltip, context);
-        final CompoundTag data = getBlockEntityData(stack);
-        if (ControllerBlockEntity.hasEnergy(data)) {
-            final long stored = ControllerBlockEntity.getStored(data);
-            final long capacity = ControllerBlockEntity.getCapacity(data);
-            tooltip.add(createStoredWithCapacityTranslation(stored, capacity, getPercentFull(stack))
-                .withStyle(ChatFormatting.GRAY));
+    protected boolean updateCustomBlockEntityTag(
+        final BlockPos pos,
+        final Level level,
+        @Nullable final Player player,
+        final ItemStack stack,
+        final BlockState blockState
+    ) {
+        final boolean result = super.updateCustomBlockEntityTag(pos, level, player, stack, blockState);
+        if (!level.isClientSide() && level.getBlockEntity(pos) instanceof ControllerBlockEntity controllerBlockEntity) {
+            PlatformApi.INSTANCE.getEnergyStorage(stack).ifPresent(
+                energyStorage -> controllerBlockEntity.loadEnergy(energyStorage.getStored())
+            );
         }
+        return result;
     }
 }

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/item/block/CreativeControllerBlockItem.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/item/block/CreativeControllerBlockItem.java
@@ -1,24 +1,13 @@
 package com.refinedmods.refinedstorage2.platform.common.item.block;
 
-import com.refinedmods.refinedstorage2.platform.api.item.HelpTooltipComponent;
-
-import java.util.Optional;
-
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.Block;
 
 import static com.refinedmods.refinedstorage2.platform.common.util.IdentifierUtil.createTranslation;
 
 public class CreativeControllerBlockItem extends NamedBlockItem {
     public CreativeControllerBlockItem(final Block block, final Component name) {
-        super(block, new Item.Properties().stacksTo(1), name);
-    }
-
-    @Override
-    public Optional<TooltipComponent> getTooltipImage(final ItemStack stack) {
-        return Optional.of(new HelpTooltipComponent(createTranslation("item", "creative_controller.help")));
+        super(block, new Item.Properties().stacksTo(1), name, createTranslation("item", "creative_controller.help"));
     }
 }

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/loot/EnergyLootItemFunction.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/loot/EnergyLootItemFunction.java
@@ -1,0 +1,32 @@
+package com.refinedmods.refinedstorage2.platform.common.loot;
+
+import com.refinedmods.refinedstorage2.api.core.Action;
+import com.refinedmods.refinedstorage2.platform.api.PlatformApi;
+import com.refinedmods.refinedstorage2.platform.api.blockentity.EnergyBlockEntity;
+import com.refinedmods.refinedstorage2.platform.common.content.LootFunctions;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+
+public class EnergyLootItemFunction implements LootItemFunction {
+    @Override
+    public LootItemFunctionType getType() {
+        return LootFunctions.INSTANCE.getEnergy();
+    }
+
+    @Override
+    public ItemStack apply(final ItemStack stack, final LootContext lootContext) {
+        final BlockEntity blockEntity = lootContext.getParam(LootContextParams.BLOCK_ENTITY);
+        if (blockEntity instanceof EnergyBlockEntity energyBlockEntity) {
+            final long stored = energyBlockEntity.getEnergyStorage().getStored();
+            PlatformApi.INSTANCE.getEnergyStorage(stack).ifPresent(
+                energyStorage -> energyStorage.receive(stored, Action.EXECUTE)
+            );
+        }
+        return stack;
+    }
+}

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/loot/EnergyLootItemFunctionSerializer.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/loot/EnergyLootItemFunctionSerializer.java
@@ -1,0 +1,22 @@
+package com.refinedmods.refinedstorage2.platform.common.loot;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import net.minecraft.world.level.storage.loot.Serializer;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
+
+public class EnergyLootItemFunctionSerializer implements Serializer<LootItemFunction> {
+    @Override
+    public void serialize(final JsonObject jsonObject,
+                          final LootItemFunction lootItemFunction,
+                          final JsonSerializationContext jsonSerializationContext) {
+        // no op
+    }
+
+    @Override
+    public LootItemFunction deserialize(final JsonObject jsonObject,
+                                        final JsonDeserializationContext jsonDeserializationContext) {
+        return new EnergyLootItemFunction();
+    }
+}

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/loot/StorageBlockLootItemFunction.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/loot/StorageBlockLootItemFunction.java
@@ -1,0 +1,44 @@
+package com.refinedmods.refinedstorage2.platform.common.loot;
+
+import com.refinedmods.refinedstorage2.platform.api.PlatformApi;
+import com.refinedmods.refinedstorage2.platform.common.block.entity.storage.AbstractStorageBlockBlockEntity;
+import com.refinedmods.refinedstorage2.platform.common.content.LootFunctions;
+
+import java.util.UUID;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.storage.loot.LootContext;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunctionType;
+import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StorageBlockLootItemFunction implements LootItemFunction {
+    private static final Logger LOGGER = LoggerFactory.getLogger(StorageBlockLootItemFunction.class);
+
+    @Override
+    public LootItemFunctionType getType() {
+        return LootFunctions.INSTANCE.getStorageBlock();
+    }
+
+    @Override
+    public ItemStack apply(final ItemStack stack, final LootContext lootContext) {
+        final BlockEntity blockEntity = lootContext.getParam(LootContextParams.BLOCK_ENTITY);
+        if (blockEntity instanceof AbstractStorageBlockBlockEntity<?> storageBlockEntity) {
+            apply(stack, storageBlockEntity);
+        }
+        return stack;
+    }
+
+    private void apply(final ItemStack stack, final AbstractStorageBlockBlockEntity<?> storageBlockEntity) {
+        final UUID storageId = storageBlockEntity.getStorageId();
+        if (storageId != null) {
+            LOGGER.debug("Transferred storage {} at {} to stack", storageId, storageBlockEntity.getBlockPos());
+            PlatformApi.INSTANCE.getStorageContainerItemHelper().setId(stack, storageId);
+        } else {
+            LOGGER.warn("Storage block {} has no associated storage ID!", storageBlockEntity.getBlockPos());
+        }
+    }
+}

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/loot/StorageBlockLootItemFunctionSerializer.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/loot/StorageBlockLootItemFunctionSerializer.java
@@ -1,0 +1,22 @@
+package com.refinedmods.refinedstorage2.platform.common.loot;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import net.minecraft.world.level.storage.loot.Serializer;
+import net.minecraft.world.level.storage.loot.functions.LootItemFunction;
+
+public class StorageBlockLootItemFunctionSerializer implements Serializer<LootItemFunction> {
+    @Override
+    public void serialize(final JsonObject jsonObject,
+                          final LootItemFunction lootItemFunction,
+                          final JsonSerializationContext jsonSerializationContext) {
+        // no op
+    }
+
+    @Override
+    public LootItemFunction deserialize(final JsonObject jsonObject,
+                                        final JsonDeserializationContext jsonDeserializationContext) {
+        return new StorageBlockLootItemFunction();
+    }
+}

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/loot/package-info.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/loot/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@FieldsAndMethodsAreNonnullByDefault
+package com.refinedmods.refinedstorage2.platform.common.loot;
+
+import com.refinedmods.refinedstorage2.api.core.FieldsAndMethodsAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/render/model/ControllerModelPredicateProvider.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/render/model/ControllerModelPredicateProvider.java
@@ -1,6 +1,6 @@
 package com.refinedmods.refinedstorage2.platform.common.render.model;
 
-import com.refinedmods.refinedstorage2.platform.common.item.block.ControllerBlockItem;
+import com.refinedmods.refinedstorage2.platform.api.PlatformApi;
 
 import javax.annotation.Nullable;
 
@@ -15,6 +15,11 @@ public class ControllerModelPredicateProvider implements ClampedItemPropertyFunc
                                @Nullable final ClientLevel level,
                                @Nullable final LivingEntity entity,
                                final int seed) {
-        return ControllerBlockItem.getPercentFull(stack);
+        if (stack.getTag() == null) { // for newly created items
+            return 1;
+        }
+        return PlatformApi.INSTANCE.getEnergyStorage(stack)
+            .map(energyStorage -> (float) energyStorage.getStored() / (float) energyStorage.getCapacity())
+            .orElse(1F);
     }
 }

--- a/refinedstorage2-platform-fabric/src/main/java/com/refinedmods/refinedstorage2/platform/fabric/ModInitializerImpl.java
+++ b/refinedstorage2-platform-fabric/src/main/java/com/refinedmods/refinedstorage2/platform/fabric/ModInitializerImpl.java
@@ -254,7 +254,7 @@ public class ModInitializerImpl extends AbstractModInitializer implements ModIni
             createIdentifier("general"),
             CreativeModeTab.builder(CreativeModeTab.Row.TOP, 0)
                 .title(createTranslation("itemGroup", "general"))
-                .icon(() -> new ItemStack(Blocks.INSTANCE.getController().getDefault()))
+                .icon(() -> new ItemStack(Blocks.INSTANCE.getCreativeController().getDefault()))
                 .displayItems((params, output) -> CreativeModeTabItems.append(output::accept))
                 .build()
         );

--- a/refinedstorage2-platform-fabric/src/main/java/com/refinedmods/refinedstorage2/platform/fabric/integration/recipemod/rei/RefinedStorageREIClientPlugin.java
+++ b/refinedstorage2-platform-fabric/src/main/java/com/refinedmods/refinedstorage2/platform/fabric/integration/recipemod/rei/RefinedStorageREIClientPlugin.java
@@ -2,13 +2,13 @@ package com.refinedmods.refinedstorage2.platform.fabric.integration.recipemod.re
 
 import com.refinedmods.refinedstorage2.platform.api.PlatformApi;
 import com.refinedmods.refinedstorage2.platform.api.integration.recipemod.IngredientConverter;
+import com.refinedmods.refinedstorage2.platform.api.item.AbstractEnergyBlockItem;
 import com.refinedmods.refinedstorage2.platform.common.block.ColorableBlock;
 import com.refinedmods.refinedstorage2.platform.common.content.BlockColorMap;
 import com.refinedmods.refinedstorage2.platform.common.content.Blocks;
 import com.refinedmods.refinedstorage2.platform.common.content.ContentIds;
 import com.refinedmods.refinedstorage2.platform.common.content.Items;
 import com.refinedmods.refinedstorage2.platform.common.content.Tags;
-import com.refinedmods.refinedstorage2.platform.common.item.block.ControllerBlockItem;
 import com.refinedmods.refinedstorage2.platform.common.screen.AbstractBaseScreen;
 
 import java.util.function.Supplier;
@@ -73,7 +73,8 @@ public class RefinedStorageREIClientPlugin implements REIClientPlugin {
         registry.group(
             createIdentifier("fully_charged_controller"),
             createTranslation("block", "controller.rei_fully_charged"),
-            ControllerBlockItem.getAllAtCapacity().map(EntryStacks::of).collect(Collectors.toList())
+            AbstractEnergyBlockItem.createAllAtEnergyCapacity(Items.INSTANCE.getControllers())
+                .map(EntryStacks::of).collect(Collectors.toList())
         );
         groupItems(
             registry,

--- a/refinedstorage2-platform-forge/src/main/java/com/refinedmods/refinedstorage2/platform/forge/datagen/loot/BlockDropProvider.java
+++ b/refinedstorage2-platform-forge/src/main/java/com/refinedmods/refinedstorage2/platform/forge/datagen/loot/BlockDropProvider.java
@@ -1,6 +1,7 @@
 package com.refinedmods.refinedstorage2.platform.forge.datagen.loot;
 
 import com.refinedmods.refinedstorage2.platform.common.content.Blocks;
+import com.refinedmods.refinedstorage2.platform.common.loot.EnergyLootItemFunction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +21,10 @@ public class BlockDropProvider extends BlockLootSubProvider {
         Blocks.INSTANCE.getCable().forEach((color, id, block) -> dropSelf(block.get()));
         Blocks.INSTANCE.getGrid().forEach((color, id, block) -> dropSelf(block.get()));
         Blocks.INSTANCE.getCraftingGrid().forEach((color, id, block) -> dropSelf(block.get()));
-        Blocks.INSTANCE.getController().forEach((color, id, block) -> dropSelf(block.get()));
+        Blocks.INSTANCE.getController().forEach((color, id, block) -> add(
+            block.get(),
+            createSingleItemTable(block.get()).apply(EnergyLootItemFunction::new)
+        ));
         Blocks.INSTANCE.getCreativeController().forEach((color, id, block) -> dropSelf(block.get()));
         Blocks.INSTANCE.getDetector().forEach((color, id, block) -> dropSelf(block.get()));
         Blocks.INSTANCE.getConstructor().forEach((color, id, block) -> dropSelf(block.get()));

--- a/refinedstorage2-platform-forge/src/main/java/com/refinedmods/refinedstorage2/platform/forge/integration/recipemod/rei/RefinedStorageREIClientPlugin.java
+++ b/refinedstorage2-platform-forge/src/main/java/com/refinedmods/refinedstorage2/platform/forge/integration/recipemod/rei/RefinedStorageREIClientPlugin.java
@@ -2,14 +2,16 @@ package com.refinedmods.refinedstorage2.platform.forge.integration.recipemod.rei
 
 import com.refinedmods.refinedstorage2.platform.api.PlatformApi;
 import com.refinedmods.refinedstorage2.platform.api.integration.recipemod.IngredientConverter;
+import com.refinedmods.refinedstorage2.platform.api.item.AbstractEnergyBlockItem;
 import com.refinedmods.refinedstorage2.platform.common.block.ColorableBlock;
 import com.refinedmods.refinedstorage2.platform.common.content.BlockColorMap;
 import com.refinedmods.refinedstorage2.platform.common.content.Blocks;
 import com.refinedmods.refinedstorage2.platform.common.content.ContentIds;
+import com.refinedmods.refinedstorage2.platform.common.content.Items;
 import com.refinedmods.refinedstorage2.platform.common.content.Tags;
-import com.refinedmods.refinedstorage2.platform.common.item.block.ControllerBlockItem;
 import com.refinedmods.refinedstorage2.platform.common.screen.AbstractBaseScreen;
 
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
@@ -17,7 +19,9 @@ import me.shedaniel.rei.api.client.registry.entry.CollapsibleEntryRegistry;
 import me.shedaniel.rei.api.client.registry.screen.ExclusionZones;
 import me.shedaniel.rei.api.client.registry.screen.ScreenRegistry;
 import me.shedaniel.rei.api.client.registry.transfer.TransferHandlerRegistry;
+import me.shedaniel.rei.api.common.entry.comparison.ItemComparatorRegistry;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
+import me.shedaniel.rei.api.common.util.EntryStacks;
 import me.shedaniel.rei.forge.REIPluginClient;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
@@ -47,6 +51,11 @@ public class RefinedStorageREIClientPlugin implements REIClientPlugin {
         registry.register(new CraftingGridTransferHandler());
     }
 
+    @Override
+    public void registerItemComparators(final ItemComparatorRegistry registry) {
+        Items.INSTANCE.getControllers().stream().map(Supplier::get).forEach(registry::registerNbt);
+    }
+
     @SuppressWarnings("UnstableApiUsage")
     @Override
     public void registerCollapsibleEntries(final CollapsibleEntryRegistry registry) {
@@ -63,7 +72,8 @@ public class RefinedStorageREIClientPlugin implements REIClientPlugin {
         registry.group(
             createIdentifier("fully_charged_controller"),
             createTranslation("block", "controller.rei_fully_charged"),
-            EntryIngredients.ofItemStacks(ControllerBlockItem.getAllAtCapacity().collect(Collectors.toSet()))
+            AbstractEnergyBlockItem.createAllAtEnergyCapacity(Items.INSTANCE.getControllers())
+                .map(EntryStacks::of).collect(Collectors.toList())
         );
         groupItems(
             registry,


### PR DESCRIPTION
Previously, item energy used to be
shoehorned in by checking the block entity
nbt.

However, we want to be able to actually
recharge the controller item,
so expose an energy capability.