### PR TITLE
fix: prevent out of bounds crashes in grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -   You can now recharge the Controller in item form.
 
+### Fixed
+
+-   Fixed a random Grid crash.
+
 ### Removed
 
 -   The `useEnergy` config option for the Wireless Grid. If you do not wish to use energy, use the

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/integration/recipemod/jei/GridGuiContainerHandler.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/integration/recipemod/jei/GridGuiContainerHandler.java
@@ -27,7 +27,7 @@ public class GridGuiContainerHandler implements IGuiContainerHandler<AbstractGri
         final double mouseX,
         final double mouseY
     ) {
-        final GridResource resource = screen.getHoveredGridResource();
+        final GridResource resource = screen.getCurrentGridResource();
         if (resource == null) {
             return Optional.empty();
         }

--- a/refinedstorage2-platform-fabric/src/main/java/com/refinedmods/refinedstorage2/platform/fabric/integration/recipemod/rei/GridFocusedStackProvider.java
+++ b/refinedstorage2-platform-fabric/src/main/java/com/refinedmods/refinedstorage2/platform/fabric/integration/recipemod/rei/GridFocusedStackProvider.java
@@ -22,7 +22,7 @@ public class GridFocusedStackProvider implements FocusedStackProvider {
         if (!(screen instanceof AbstractGridScreen<?> gridScreen)) {
             return CompoundEventResult.pass();
         }
-        final GridResource resource = gridScreen.getHoveredGridResource();
+        final GridResource resource = gridScreen.getCurrentGridResource();
         if (resource == null) {
             return CompoundEventResult.pass();
         }

--- a/refinedstorage2-platform-forge/src/main/java/com/refinedmods/refinedstorage2/platform/forge/integration/recipemod/rei/GridFocusedStackProvider.java
+++ b/refinedstorage2-platform-forge/src/main/java/com/refinedmods/refinedstorage2/platform/forge/integration/recipemod/rei/GridFocusedStackProvider.java
@@ -22,7 +22,7 @@ public class GridFocusedStackProvider implements FocusedStackProvider {
         if (!(screen instanceof AbstractGridScreen<?> gridScreen)) {
             return CompoundEventResult.pass();
         }
-        final GridResource resource = gridScreen.getHoveredGridResource();
+        final GridResource resource = gridScreen.getCurrentGridResource();
         if (resource == null) {
             return CompoundEventResult.pass();
         }


### PR DESCRIPTION
Prefer using GridResource instances instead of an integer value that can change after checking.
Fixes #424