### PR TITLE
fix: tooltip rendering order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+-   Side button tooltip rendering issue with ModernUI.
+
 ## [2.0.0-milestone.3.8] - 2024-06-08
 
 ### Removed

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/support/AbstractBaseScreen.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/support/AbstractBaseScreen.java
@@ -50,6 +50,9 @@ public abstract class AbstractBaseScreen<T extends AbstractContainerMenu> extend
     private final List<Rect2i> exclusionZones = new ArrayList<>();
     private int sideButtonY;
 
+    @Nullable
+    private List<ClientTooltipComponent> deferredTooltip;
+
     protected AbstractBaseScreen(final T menu, final Inventory playerInventory, final Component text) {
         super(menu, playerInventory, text);
         this.playerInventory = playerInventory;
@@ -189,7 +192,15 @@ public abstract class AbstractBaseScreen<T extends AbstractContainerMenu> extend
                 return;
             }
         }
+        if (deferredTooltip != null) {
+            Platform.INSTANCE.renderTooltip(graphics, deferredTooltip, x, y);
+            deferredTooltip = null;
+        }
         super.renderTooltip(graphics, x, y);
+    }
+
+    public void setDeferredTooltip(@Nullable final List<ClientTooltipComponent> deferredTooltip) {
+        this.deferredTooltip = deferredTooltip;
     }
 
     private List<ClientTooltipComponent> getUpgradeTooltip(final ItemStack carried, final UpgradeSlot upgradeSlot) {

--- a/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/support/widget/AbstractSideButtonWidget.java
+++ b/refinedstorage2-platform-common/src/main/java/com/refinedmods/refinedstorage2/platform/common/support/widget/AbstractSideButtonWidget.java
@@ -1,6 +1,6 @@
 package com.refinedmods.refinedstorage2.platform.common.support.widget;
 
-import com.refinedmods.refinedstorage2.platform.common.Platform;
+import com.refinedmods.refinedstorage2.platform.common.support.AbstractBaseScreen;
 import com.refinedmods.refinedstorage2.platform.common.support.TextureIds;
 import com.refinedmods.refinedstorage2.platform.common.support.tooltip.HelpClientTooltipComponent;
 import com.refinedmods.refinedstorage2.platform.common.support.tooltip.SmallTextClientTooltipComponent;
@@ -11,8 +11,10 @@ import javax.annotation.Nullable;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.minecraft.ChatFormatting;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -66,7 +68,10 @@ public abstract class AbstractSideButtonWidget extends Button {
             graphics.blit(getTextureIdentifier(), getX(), getY(), 238, 54, WIDTH, HEIGHT);
             RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.disableBlend();
-            Platform.INSTANCE.renderTooltip(graphics, buildTooltip(), mouseX, mouseY);
+            final Screen screen = Minecraft.getInstance().screen;
+            if (screen instanceof AbstractBaseScreen<?> baseScreen) {
+                baseScreen.setDeferredTooltip(buildTooltip());
+            }
         }
         if (warning != null) {
             renderWarning(graphics);


### PR DESCRIPTION
ModernUI relies on the correct order.
Fixes #543 