### PR TITLE
fix: crash when trying to export fluids on Fabric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -  Ability to extract fluids from the Interface using an empty bucket or other empty fluid container.
 
+### Fixed
+
+-  Fixed crash when trying to export fluids into an Interface on Fabric.
+
 ## [2.0.0-milestone.4.4] - 2024-07-10
 
 ## [2.0.0-milestone.4.3] - 2024-07-06

--- a/refinedstorage-platform-fabric/src/main/java/com/refinedmods/refinedstorage/platform/fabric/storage/FabricStorageInsertableStorage.java
+++ b/refinedstorage-platform-fabric/src/main/java/com/refinedmods/refinedstorage/platform/fabric/storage/FabricStorageInsertableStorage.java
@@ -41,6 +41,9 @@ public class FabricStorageInsertableStorage<T> implements InsertableStorage {
             return 0;
         }
         final T platformResource = toPlatformMapper.apply(resource);
+        if (platformResource == null) {
+            return 0;
+        }
         final long correctedAmount = amountOverride.overrideAmount(
             resource,
             amount,


### PR DESCRIPTION
If the destination supports items and fluids, and we try to export fluids, it would also try the item strategy,
and try to convert fluid into an item,
which doesn't work, and throws an NPE.

Fixes #621 