### PR TITLE
fix: support fabric context update mutated stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed fabric energy item update
+
 ## [2.0.0-milestone.4.10] - 2024-11-24
 
 ### Added

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/energy/ItemBlockEnergyStorage.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/energy/ItemBlockEnergyStorage.java
@@ -29,6 +29,10 @@ public class ItemBlockEnergyStorage extends AbstractListeningEnergyStorage {
         }
     }
 
+    public ItemStack getStack() {
+        return stack;
+    }
+
     @Override
     protected void onStoredChanged(final long stored) {
         final CustomData customData = stack.get(DataComponents.BLOCK_ENTITY_DATA);

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/energy/ItemEnergyStorage.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/energy/ItemEnergyStorage.java
@@ -19,6 +19,10 @@ public class ItemEnergyStorage extends AbstractListeningEnergyStorage {
         }
     }
 
+    public ItemStack getStack() {
+        return stack;
+    }
+
     @Override
     protected void onStoredChanged(final long stored) {
         stack.set(DataComponents.INSTANCE.getEnergy(), stored);

--- a/refinedstorage-fabric/src/main/java/com/refinedmods/refinedstorage/fabric/ModInitializerImpl.java
+++ b/refinedstorage-fabric/src/main/java/com/refinedmods/refinedstorage/fabric/ModInitializerImpl.java
@@ -828,20 +828,22 @@ public class ModInitializerImpl extends AbstractModInitializer implements ModIni
 
     private void registerEnergyItemProviders() {
         EnergyStorage.ITEM.registerForItems(
-            (stack, context) -> new EnergyStorageAdapter(Items.INSTANCE.getWirelessGrid().createEnergyStorage(stack)),
+            (stack, context) ->
+                new EnergyStorageAdapter(Items.INSTANCE.getWirelessGrid().createEnergyStorage(stack), context),
             Items.INSTANCE.getWirelessGrid()
         );
         Items.INSTANCE.getControllers().forEach(controller -> EnergyStorage.ITEM.registerForItems(
-            (stack, context) -> new EnergyStorageAdapter(controller.get().createEnergyStorage(stack)),
+            (stack, context) -> new EnergyStorageAdapter(controller.get().createEnergyStorage(stack), context),
             controller.get()
         ));
         EnergyStorage.ITEM.registerForItems(
-            (stack, context) -> new EnergyStorageAdapter(PortableGridBlockItem.createEnergyStorage(stack)),
+            (stack, context) -> new EnergyStorageAdapter(PortableGridBlockItem.createEnergyStorage(stack), context),
             Items.INSTANCE.getPortableGrid()
         );
         EnergyStorage.ITEM.registerForItems(
             (stack, context) ->
-                new EnergyStorageAdapter(Items.INSTANCE.getWirelessAutocraftingMonitor().createEnergyStorage(stack)),
+                new EnergyStorageAdapter(Items.INSTANCE.getWirelessAutocraftingMonitor().createEnergyStorage(stack),
+                    context),
             Items.INSTANCE.getWirelessAutocraftingMonitor()
         );
     }

--- a/refinedstorage-fabric/src/main/java/com/refinedmods/refinedstorage/fabric/support/energy/EnergyStorageAdapter.java
+++ b/refinedstorage-fabric/src/main/java/com/refinedmods/refinedstorage/fabric/support/energy/EnergyStorageAdapter.java
@@ -2,12 +2,26 @@ package com.refinedmods.refinedstorage.fabric.support.energy;
 
 import com.refinedmods.refinedstorage.api.core.Action;
 import com.refinedmods.refinedstorage.api.network.energy.EnergyStorage;
+import com.refinedmods.refinedstorage.common.support.energy.ItemBlockEnergyStorage;
+import com.refinedmods.refinedstorage.common.support.energy.ItemEnergyStorage;
 
+import javax.annotation.Nullable;
+
+import net.fabricmc.fabric.api.transfer.v1.context.ContainerItemContext;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.fabricmc.fabric.api.transfer.v1.transaction.base.SnapshotParticipant;
+import net.minecraft.world.item.ItemStack;
 
 public class EnergyStorageAdapter extends SnapshotParticipant<Long> implements team.reborn.energy.api.EnergyStorage {
+    @Nullable
+    private ContainerItemContext ctx;
     private final EnergyStorage energyStorage;
+
+    public EnergyStorageAdapter(final EnergyStorage energyStorage, final ContainerItemContext ctx) {
+        this.energyStorage = energyStorage;
+        this.ctx = ctx;
+    }
 
     public EnergyStorageAdapter(final EnergyStorage energyStorage) {
         this.energyStorage = energyStorage;
@@ -17,22 +31,40 @@ public class EnergyStorageAdapter extends SnapshotParticipant<Long> implements t
         return energyStorage;
     }
 
+    public void exchangeStack(final TransactionContext transaction) {
+        if (ctx != null) {
+            ItemStack itemStack = null;
+            if (energyStorage instanceof ItemBlockEnergyStorage itemBlockEnergyStorage) {
+                itemStack = itemBlockEnergyStorage.getStack();
+            } else if (energyStorage instanceof ItemEnergyStorage itemEnergyStorage) {
+                itemStack = itemEnergyStorage.getStack();
+            }
+            if (itemStack != null) {
+                ctx.exchange(ItemVariant.of(itemStack), 1, transaction);
+            }
+        }
+    }
+
     @Override
     public long insert(final long maxAmount, final TransactionContext transaction) {
-        final long insertedSimulated = energyStorage.receive(maxAmount, Action.SIMULATE);
-        if (insertedSimulated > 0) {
+        long inserted = energyStorage.receive(maxAmount, Action.SIMULATE);
+        if (inserted > 0) {
             updateSnapshots(transaction);
         }
-        return energyStorage.receive(maxAmount, Action.EXECUTE);
+        inserted = energyStorage.receive(maxAmount, Action.EXECUTE);
+        exchangeStack(transaction);
+        return inserted;
     }
 
     @Override
     public long extract(final long maxAmount, final TransactionContext transaction) {
-        final long extractedSimulated = energyStorage.extract(maxAmount, Action.SIMULATE);
-        if (extractedSimulated > 0) {
+        long extracted = energyStorage.extract(maxAmount, Action.SIMULATE);
+        if (extracted > 0) {
             updateSnapshots(transaction);
         }
-        return energyStorage.extract(maxAmount, Action.EXECUTE);
+        extracted = energyStorage.extract(maxAmount, Action.EXECUTE);
+        exchangeStack(transaction);
+        return extracted;
     }
 
     @Override


### PR DESCRIPTION
Add ContainerItemContext support to EnergyStorageAdapter
related to https://github.com/TechReborn/TechReborn/issues/3302

## Question:
`EnergyStorage.ITEM.registerForItems` has context parameter but is not used.
https://github.com/refinedmods/refinedstorage2/blob/a18776d8a71d261c52eaebcb79259d5e89999dd8/refinedstorage-fabric/src/main/java/com/refinedmods/refinedstorage/fabric/ModInitializerImpl.java#L829-L847
Discovered by comparing TechReborn:
https://github.com/TechReborn/Energy/blob/da313914b1efe29632300900ba06f95e8c1d60b8/src/main/java/team/reborn/energy/impl/EnergyImpl.java#L23-L29
```java
EnergyStorage.ITEM.registerFallback((stack, ctx) -> {
        if (stack.getItem() instanceof SimpleEnergyItem energyItem) {
                return SimpleEnergyItem.createStorage(ctx, energyItem.getEnergyCapacity(stack), energyItem.getEnergyMaxInput(stack), energyItem.getEnergyMaxOutput(stack));
        } else {
                return null;
        }
});
```
https://github.com/TechReborn/Energy/blob/da313914b1efe29632300900ba06f95e8c1d60b8/src/main/java/team/reborn/energy/impl/SimpleItemEnergyStorageImpl.java#L48-L62
```java
private final ContainerItemContext ctx;
...
private boolean trySetEnergy(long energyAmountPerCount, long count, TransactionContext transaction) {
        ItemStack newStack = ctx.getItemVariant().toStack();
        SimpleEnergyItem.setStoredEnergyUnchecked(newStack, energyAmountPerCount);
        ItemVariant newVariant = ItemVariant.of(newStack);

        // Try to convert exactly `count` items.
        try (Transaction nested = transaction.openNested()) {
                if (ctx.extract(ctx.getItemVariant(), count, nested) == count && ctx.insert(newVariant, count, nested) == count) {
                        nested.commit();
                        return true;
                }
        }

        return false;
}
```

## Simple fix:
```java
if (ctx != null) {
        ItemStack itemStack = null;
        if (energyStorage instanceof ItemBlockEnergyStorage itemBlockEnergyStorage) {
                itemStack = itemBlockEnergyStorage.getStack();
        } else if (energyStorage instanceof ItemEnergyStorage itemEnergyStorage) {
                itemStack = itemEnergyStorage.getStack();
        }
        if (itemStack != null) {
                ctx.exchange(ItemVariant.of(itemStack), 1, transaction);
        }
}
```
![screenshots](https://github.com/user-attachments/assets/80e77177-c481-4524-a7c9-648938309d4d)

Because the code structure is too nested, itemStack cannot be accessed directly, so it is obtained through `instanceof`. 
**Maybe the data structure needs to be optimized**