### PR TITLE
fix: protect against crashes from other mods when trying to build tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+-   Fixed External Fluid not connecting properly to fluid storages.
+-   Fixed Interface filter not respecting maximum stack size of a resource.
+-   Fixed potential crash when trying to build cable shapes.
+-   Fixed storage disk upgrade recipes not showing properly in recipe viewers.
+-   Protect against crashes from other mods when trying to build the cached Grid tooltip.
+
 ## [2.0.0-milestone.4.10] - 2024-11-24
 
 ### Added
@@ -19,13 +27,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -   The Autocrafting Monitor now has a sidebar with all tasks instead of using tabs.
 -   The auto-selected search box mode is now a global option used in the Autocrafter Manager as well.
-
-### Fixed
-
--   Fixed External Fluid not connecting properly to fluid storages.
--   Fixed Interface filter not respecting maximum stack size of a resource.
--   Fixed potential crash when trying to build cable shapes.
--   Fixed storage disk upgrade recipes not showing properly in recipe viewers.
 
 ### Removed
 

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -63,7 +63,6 @@
             <property name="ignoreConstructorParameter" value="true"/>
             <property name="ignoreSetter" value="true"/>
         </module>
-        <module name="IllegalCatch"/>
         <module name="IllegalInstantiation"/>
         <module name="IllegalThrows"/>
         <module name="IllegalToken"/>

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/AbstractItemGridResourceFactory.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/AbstractItemGridResourceFactory.java
@@ -17,8 +17,12 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractItemGridResourceFactory implements GridResourceFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractItemGridResourceFactory.class);
+
     @Override
     public Optional<GridResource> apply(final ResourceKey resource, final boolean autocraftable) {
         if (!(resource instanceof ItemResource itemResource)) {
@@ -46,11 +50,16 @@ public abstract class AbstractItemGridResourceFactory implements GridResourceFac
     }
 
     private String getTooltip(final ItemStack itemStack) {
-        return itemStack
-            .getTooltipLines(Item.TooltipContext.EMPTY, null, TooltipFlag.ADVANCED)
-            .stream()
-            .map(Component::getString)
-            .collect(Collectors.joining("\n"));
+        try {
+            return itemStack
+                .getTooltipLines(Item.TooltipContext.EMPTY, null, TooltipFlag.ADVANCED)
+                .stream()
+                .map(Component::getString)
+                .collect(Collectors.joining("\n"));
+        } catch (final Throwable t) {
+            LOGGER.warn("Failed to get tooltip for item {}", itemStack, t);
+            return "";
+        }
     }
 
     private Set<String> getTags(final Item item) {

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/ItemGridResource.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/ItemGridResource.java
@@ -13,6 +13,7 @@ import com.refinedmods.refinedstorage.common.support.resource.ItemResource;
 import com.refinedmods.refinedstorage.common.support.resource.ResourceTypes;
 import com.refinedmods.refinedstorage.common.support.tooltip.MouseClientTooltipComponent;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,11 +29,15 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.refinedmods.refinedstorage.common.util.IdentifierUtil.format;
 import static com.refinedmods.refinedstorage.common.util.IdentifierUtil.formatWithUnits;
 
 public class ItemGridResource extends AbstractPlatformGridResource<ItemResource> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ItemGridResource.class);
+
     private final int id;
     private final ItemStack itemStack;
     private final ItemResource itemResource;
@@ -106,8 +111,12 @@ public class ItemGridResource extends AbstractPlatformGridResource<ItemResource>
     @Override
     public void render(final GuiGraphics graphics, final int x, final int y) {
         final Font font = Minecraft.getInstance().font;
-        graphics.renderItem(itemStack, x, y);
-        graphics.renderItemDecorations(font, itemStack, x, y, null);
+        try {
+            graphics.renderItem(itemStack, x, y);
+            graphics.renderItemDecorations(font, itemStack, x, y, null);
+        } catch (final Throwable t) {
+            LOGGER.warn("Failed to render item {}", itemStack, t);
+        }
     }
 
     @Override
@@ -128,7 +137,12 @@ public class ItemGridResource extends AbstractPlatformGridResource<ItemResource>
     @Override
     public List<Component> getTooltip() {
         final Minecraft minecraft = Minecraft.getInstance();
-        return Screen.getTooltipFromItem(minecraft, itemStack);
+        try {
+            return Screen.getTooltipFromItem(minecraft, itemStack);
+        } catch (final Throwable t) {
+            LOGGER.warn("Failed to get tooltip for item {}", itemStack, t);
+            return Collections.emptyList();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #716 