### PR TITLE
feat: relay support for autocrafting tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ###  Added
 
 -   Colored variants are now moved to a separate creative mode tab.
+-   You can now start autocrafting tasks in the Relay's output network, using patterns and autocrafters from the input network.
 
 ### Fixed
 

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/ExternalPatternSink.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/ExternalPatternSink.java
@@ -21,11 +21,12 @@ public interface ExternalPatternSink {
      * If the sink is locked, it must return {@link Result#LOCKED}.
      * If the resources are not applicable for this sink, it must return {@link Result#SKIPPED}.
      *
+     * @param pattern   the pattern
      * @param resources the resources
      * @param action    the action
      * @return the result
      */
-    Result accept(Collection<ResourceAmount> resources, Action action);
+    Result accept(Pattern pattern, Collection<ResourceAmount> resources, Action action);
 
     /**
      * @return the key for this sink

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/ExternalTaskPattern.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/ExternalTaskPattern.java
@@ -194,7 +194,7 @@ class ExternalTaskPattern extends AbstractTaskPattern {
         // across the sink and the internal storage.
         // The end result is that we lie, do as if the insertion was successful,
         // and potentially void the extracted resources from the internal storage.
-        if (sink.accept(iterationInputs.copyState(), Action.EXECUTE) != ExternalPatternSink.Result.ACCEPTED) {
+        if (sink.accept(pattern, iterationInputs.copyState(), Action.EXECUTE) != ExternalPatternSink.Result.ACCEPTED) {
             LOGGER.warn("Sink {} did not accept all inputs for pattern {}", sink, pattern);
         }
         return true;
@@ -209,6 +209,7 @@ class ExternalTaskPattern extends AbstractTaskPattern {
         while (currentSinkIndex < sinks.size()) {
             final ExternalPatternSink sink = sinks.get(currentSinkIndex);
             final ExternalPatternSink.Result simulatedResult = sink.accept(
+                pattern,
                 iterationInputsSimulated.copyState(),
                 Action.SIMULATE
             );

--- a/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/task/ExternalPatternSinkProviderImpl.java
+++ b/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/task/ExternalPatternSinkProviderImpl.java
@@ -72,7 +72,9 @@ class ExternalPatternSinkProviderImpl implements ExternalPatternSinkProvider {
         }
 
         @Override
-        public Result accept(final Collection<ResourceAmount> resources, final Action action) {
+        public Result accept(final Pattern p,
+                             final Collection<ResourceAmount> resources,
+                             final Action action) {
             if (fixedResult != null) {
                 return fixedResult;
             }

--- a/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/task/TaskImplTest.java
+++ b/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/task/TaskImplTest.java
@@ -765,7 +765,7 @@ class TaskImplTest {
         );
         final PatternRepository patterns = patterns(IRON_INGOT_PATTERN, IRON_PICKAXE_PATTERN);
         final ExternalPatternSinkProviderImpl sinkProvider = new ExternalPatternSinkProviderImpl();
-        sinkProvider.put(IRON_INGOT_PATTERN, (resources, action) -> action == Action.EXECUTE
+        sinkProvider.put(IRON_INGOT_PATTERN, (pattern, resources, action) -> action == Action.EXECUTE
             ? ExternalPatternSink.Result.REJECTED
             : ExternalPatternSink.Result.ACCEPTED);
         final Task task = getRunningTask(storage, patterns, sinkProvider, IRON_PICKAXE, 1);

--- a/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/autocrafting/TaskContainer.java
+++ b/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/autocrafting/TaskContainer.java
@@ -1,0 +1,120 @@
+package com.refinedmods.refinedstorage.api.network.impl.autocrafting;
+
+import com.refinedmods.refinedstorage.api.autocrafting.status.TaskStatus;
+import com.refinedmods.refinedstorage.api.autocrafting.task.ExternalPatternSinkProvider;
+import com.refinedmods.refinedstorage.api.autocrafting.task.StepBehavior;
+import com.refinedmods.refinedstorage.api.autocrafting.task.Task;
+import com.refinedmods.refinedstorage.api.autocrafting.task.TaskId;
+import com.refinedmods.refinedstorage.api.autocrafting.task.TaskListener;
+import com.refinedmods.refinedstorage.api.autocrafting.task.TaskState;
+import com.refinedmods.refinedstorage.api.network.Network;
+import com.refinedmods.refinedstorage.api.network.autocrafting.AutocraftingNetworkComponent;
+import com.refinedmods.refinedstorage.api.network.autocrafting.ParentContainer;
+import com.refinedmods.refinedstorage.api.network.autocrafting.PatternProvider;
+import com.refinedmods.refinedstorage.api.network.storage.StorageNetworkComponent;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TaskContainer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TaskContainer.class);
+
+    private final PatternProvider patternProvider;
+    private final List<Task> tasks = new CopyOnWriteArrayList<>();
+    private final List<Task> tasksView = Collections.unmodifiableList(tasks);
+    private final Set<ParentContainer> parents = new HashSet<>();
+
+    public TaskContainer(final PatternProvider patternProvider) {
+        this.patternProvider = patternProvider;
+    }
+
+    public List<Task> getAll() {
+        return tasksView;
+    }
+
+    public List<TaskStatus> getStatuses() {
+        return tasks.stream().map(Task::getStatus).toList();
+    }
+
+    public void onRemovedFromContainer(final ParentContainer parent) {
+        tasks.forEach(parent::taskRemoved);
+        parents.remove(parent);
+    }
+
+    public void onAddedIntoContainer(final ParentContainer parent) {
+        tasks.forEach(task -> parent.taskAdded(patternProvider, task));
+        parents.add(parent);
+    }
+
+    public void add(final Task task, @Nullable final Network network) {
+        tasks.add(task);
+        if (network != null) {
+            attach(task, network.getComponent(StorageNetworkComponent.class));
+        }
+    }
+
+    public void cancel(final TaskId id) {
+        for (final Task task : tasks) {
+            if (task.getId().equals(id)) {
+                task.cancel();
+                return;
+            }
+        }
+        throw new IllegalArgumentException("Task %s not found".formatted(id));
+    }
+
+    public void attachAll(final Network network) {
+        final StorageNetworkComponent storage = network.getComponent(StorageNetworkComponent.class);
+        tasks.forEach(task -> attach(task, storage));
+    }
+
+    public void detachAll(final Network network) {
+        final StorageNetworkComponent storage = network.getComponent(StorageNetworkComponent.class);
+        tasks.forEach(task -> detach(task, storage));
+    }
+
+    private void attach(final Task task, final StorageNetworkComponent storage) {
+        storage.addListener(task);
+    }
+
+    private void detach(final Task task, final StorageNetworkComponent storage) {
+        storage.removeListener(task);
+    }
+
+    public void step(final Network network, final StepBehavior stepBehavior, final TaskListener listener) {
+        final StorageNetworkComponent storage = network.getComponent(StorageNetworkComponent.class);
+        final ExternalPatternSinkProvider sinkProvider = network.getComponent(AutocraftingNetworkComponent.class);
+        tasks.removeIf(task -> step(task, storage, sinkProvider, stepBehavior, listener));
+    }
+
+    private boolean step(final Task task,
+                         final StorageNetworkComponent storage,
+                         final ExternalPatternSinkProvider sinkProvider,
+                         final StepBehavior stepBehavior,
+                         final TaskListener listener) {
+        boolean changed;
+        boolean completed;
+        try {
+            changed = task.step(storage, sinkProvider, stepBehavior, listener);
+            completed = task.getState() == TaskState.COMPLETED;
+        } catch (final Exception e) {
+            LOGGER.error("Exception while stepping task {} {}, removing task", task.getResource(), task.getAmount(), e);
+            changed = false;
+            completed = true;
+        }
+        if (completed) {
+            detach(task, storage);
+            parents.forEach(parent -> parent.taskCompleted(task));
+        } else if (changed) {
+            parents.forEach(parent -> parent.taskChanged(task));
+        }
+        return completed;
+    }
+}

--- a/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/node/patternprovider/PatternProviderExternalPatternSinkImpl.java
+++ b/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/node/patternprovider/PatternProviderExternalPatternSinkImpl.java
@@ -10,7 +10,7 @@ import com.refinedmods.refinedstorage.api.storage.StorageImpl;
 
 import java.util.Collection;
 
-class PatternProviderExternalPatternSinkImpl implements PatternProviderExternalPatternSink {
+public class PatternProviderExternalPatternSinkImpl implements PatternProviderExternalPatternSink {
     private final Storage storage = new StorageImpl();
 
     @Override
@@ -22,7 +22,7 @@ class PatternProviderExternalPatternSinkImpl implements PatternProviderExternalP
         return ExternalPatternSink.Result.ACCEPTED;
     }
 
-    Collection<ResourceAmount> getAll() {
+    public Collection<ResourceAmount> getAll() {
         return storage.getAll();
     }
 }

--- a/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/node/relay/RelayAutocraftingNetworkNodeTest.java
+++ b/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/node/relay/RelayAutocraftingNetworkNodeTest.java
@@ -1,18 +1,37 @@
 package com.refinedmods.refinedstorage.api.network.impl.node.relay;
 
+import com.refinedmods.refinedstorage.api.autocrafting.Pattern;
+import com.refinedmods.refinedstorage.api.autocrafting.PatternType;
+import com.refinedmods.refinedstorage.api.autocrafting.status.TaskStatus;
+import com.refinedmods.refinedstorage.api.autocrafting.status.TaskStatusListener;
+import com.refinedmods.refinedstorage.api.autocrafting.task.StepBehavior;
+import com.refinedmods.refinedstorage.api.autocrafting.task.TaskId;
+import com.refinedmods.refinedstorage.api.autocrafting.task.TaskState;
+import com.refinedmods.refinedstorage.api.core.Action;
 import com.refinedmods.refinedstorage.api.network.Network;
 import com.refinedmods.refinedstorage.api.network.autocrafting.AutocraftingNetworkComponent;
+import com.refinedmods.refinedstorage.api.network.impl.node.patternprovider.PatternProviderExternalPatternSinkImpl;
+import com.refinedmods.refinedstorage.api.network.impl.node.patternprovider.PatternProviderListener;
+import com.refinedmods.refinedstorage.api.network.impl.node.patternprovider.PatternProviderNetworkNode;
+import com.refinedmods.refinedstorage.api.network.storage.StorageNetworkComponent;
+import com.refinedmods.refinedstorage.api.resource.ResourceAmount;
 import com.refinedmods.refinedstorage.api.resource.filter.FilterMode;
+import com.refinedmods.refinedstorage.api.storage.Actor;
+import com.refinedmods.refinedstorage.api.storage.StorageImpl;
 import com.refinedmods.refinedstorage.network.test.AddNetworkNode;
 import com.refinedmods.refinedstorage.network.test.InjectNetwork;
 import com.refinedmods.refinedstorage.network.test.InjectNetworkAutocraftingComponent;
+import com.refinedmods.refinedstorage.network.test.InjectNetworkStorageComponent;
 import com.refinedmods.refinedstorage.network.test.NetworkTest;
 import com.refinedmods.refinedstorage.network.test.SetupNetwork;
 
 import java.util.Set;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
+import static com.refinedmods.refinedstorage.api.autocrafting.PatternBuilder.pattern;
 import static com.refinedmods.refinedstorage.api.network.impl.node.relay.RelayNetworkNodeTest.addPattern;
 import static com.refinedmods.refinedstorage.network.test.fixtures.ResourceFixtures.A;
 import static com.refinedmods.refinedstorage.network.test.fixtures.ResourceFixtures.A_ALTERNATIVE;
@@ -21,6 +40,12 @@ import static com.refinedmods.refinedstorage.network.test.fixtures.ResourceFixtu
 import static com.refinedmods.refinedstorage.network.test.fixtures.ResourceFixtures.D;
 import static com.refinedmods.refinedstorage.network.test.nodefactory.AbstractNetworkNodeFactory.PROPERTY_ACTIVE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @NetworkTest
 @SetupNetwork(id = "input")
@@ -321,5 +346,434 @@ class RelayAutocraftingNetworkNodeTest {
         // Assert
         assertThat(inputAutocrafting.getOutputs()).usingRecursiveFieldByFieldElementComparator().containsExactly(A);
         assertThat(inputAlternativeAutocrafting.getOutputs()).isEmpty();
+    }
+
+    @Test
+    void shouldUseResourcesFromOutputNetworkForCalculation(
+        @InjectNetworkAutocraftingComponent(networkId = "input") final AutocraftingNetworkComponent inputAutocrafting,
+        @InjectNetworkAutocraftingComponent(networkId = "output") final AutocraftingNetworkComponent outputAutocrafting,
+        @InjectNetworkStorageComponent(networkId = "output") final StorageNetworkComponent outputStorage
+    ) {
+        // Arrange
+        input.setActive(true);
+        input.setOutputNode(output);
+
+        final PatternProviderNetworkNode patternProvider = new PatternProviderNetworkNode(0, 1);
+        patternProvider.setPattern(0, pattern()
+            .ingredient(A, 1)
+            .output(B, 1)
+            .build());
+        inputAutocrafting.onContainerAdded(() -> patternProvider);
+
+        outputStorage.addSource(new StorageImpl());
+        outputStorage.insert(A, 1, Action.EXECUTE, Actor.EMPTY);
+
+        input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
+
+        // Act
+        final var taskIdFromOutput = outputAutocrafting.startTask(B, 1, Actor.EMPTY, false).join();
+        final var taskIdFromInput = inputAutocrafting.startTask(B, 1, Actor.EMPTY, false).join();
+
+        // Assert
+        assertThat(taskIdFromOutput).isPresent();
+        assertThat(taskIdFromInput).isEmpty();
+    }
+
+    @Test
+    void shouldStartTaskInOutputPatternProvider(
+        @InjectNetworkAutocraftingComponent(networkId = "input") final AutocraftingNetworkComponent inputAutocrafting,
+        @InjectNetworkAutocraftingComponent(networkId = "output") final AutocraftingNetworkComponent outputAutocrafting,
+        @InjectNetworkStorageComponent(networkId = "output") final StorageNetworkComponent outputStorage
+    ) {
+        // Arrange
+        input.setActive(true);
+        input.setOutputNode(output);
+
+        final PatternProviderNetworkNode patternProvider = new PatternProviderNetworkNode(0, 1);
+        patternProvider.setPattern(0, pattern()
+            .ingredient(A, 1)
+            .output(B, 1)
+            .build());
+        inputAutocrafting.onContainerAdded(() -> patternProvider);
+
+        outputStorage.addSource(new StorageImpl());
+        outputStorage.insert(A, 1, Action.EXECUTE, Actor.EMPTY);
+
+        input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
+
+        final var optionalTaskId = outputAutocrafting.startTask(B, 1, Actor.EMPTY, false).join();
+        assertThat(optionalTaskId).isPresent();
+
+        // Act
+        assertThat(output.getTasks()).hasSize(1);
+        assertThat(inputAutocrafting.getStatuses()).isEmpty();
+        assertThat(outputAutocrafting.getStatuses()).hasSize(1);
+    }
+
+    @Test
+    void shouldCancelTask(
+        @InjectNetworkAutocraftingComponent(networkId = "input") final AutocraftingNetworkComponent inputAutocrafting,
+        @InjectNetworkAutocraftingComponent(networkId = "output") final AutocraftingNetworkComponent outputAutocrafting,
+        @InjectNetworkStorageComponent(networkId = "output") final StorageNetworkComponent outputStorage
+    ) {
+        // Arrange
+        input.setActive(true);
+        input.setOutputNode(output);
+
+        final PatternProviderNetworkNode patternProvider = new PatternProviderNetworkNode(0, 1);
+        patternProvider.setPattern(0, pattern()
+            .ingredient(A, 1)
+            .output(B, 1)
+            .build());
+        inputAutocrafting.onContainerAdded(() -> patternProvider);
+
+        outputStorage.addSource(new StorageImpl());
+        outputStorage.insert(A, 1, Action.EXECUTE, Actor.EMPTY);
+
+        input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
+
+        // Act & assert
+        final var optionalTaskId = outputAutocrafting.startTask(B, 1, Actor.EMPTY, false).join();
+        assertThat(optionalTaskId).isPresent();
+        final var taskId = optionalTaskId.get();
+        assertThat(output.getTasks())
+            .hasSize(1)
+            .allMatch(task -> task.getId().equals(taskId) && task.getState() == TaskState.READY);
+
+        inputAutocrafting.cancel(taskId);
+        assertThat(output.getTasks())
+            .hasSize(1)
+            .allMatch(task -> task.getId().equals(taskId) && task.getState() == TaskState.READY);
+
+        outputAutocrafting.cancel(taskId);
+        assertThat(output.getTasks())
+            .hasSize(1)
+            .allMatch(task -> task.getId().equals(taskId) && task.getState() == TaskState.RETURNING_INTERNAL_STORAGE);
+    }
+
+    @Test
+    void shouldStepTasks(
+        @InjectNetworkAutocraftingComponent(networkId = "input") final AutocraftingNetworkComponent inputAutocrafting,
+        @InjectNetworkAutocraftingComponent(networkId = "output") final AutocraftingNetworkComponent outputAutocrafting,
+        @InjectNetworkStorageComponent(networkId = "output") final StorageNetworkComponent outputStorage
+    ) {
+        // Arrange
+        input.setActive(true);
+        input.setOutputNode(output);
+
+        final PatternProviderNetworkNode patternProvider = new PatternProviderNetworkNode(0, 1);
+        patternProvider.setPattern(0, pattern()
+            .ingredient(A, 1)
+            .output(B, 1)
+            .build());
+        inputAutocrafting.onContainerAdded(() -> patternProvider);
+
+        outputStorage.addSource(new StorageImpl());
+        outputStorage.insert(A, 1, Action.EXECUTE, Actor.EMPTY);
+
+        input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
+
+        assertThat(outputAutocrafting.startTask(B, 1, Actor.EMPTY, false).join()).isPresent();
+
+        // Act & assert
+        output.doWork();
+        assertThat(output.getTasks()).hasSize(1);
+
+        output.doWork();
+        assertThat(output.getTasks()).isEmpty();
+
+        assertThat(outputStorage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+            new ResourceAmount(B, 1)
+        );
+    }
+
+    @Test
+    void shouldStepTasksWithCustomStepBehavior(
+        @InjectNetworkAutocraftingComponent(networkId = "input") final AutocraftingNetworkComponent inputAutocrafting,
+        @InjectNetworkAutocraftingComponent(networkId = "output") final AutocraftingNetworkComponent outputAutocrafting,
+        @InjectNetworkStorageComponent(networkId = "output") final StorageNetworkComponent outputStorage
+    ) {
+        // Arrange
+        input.setActive(true);
+        input.setOutputNode(output);
+
+        final PatternProviderNetworkNode patternProvider = new PatternProviderNetworkNode(0, 1);
+        patternProvider.setPattern(0, pattern()
+            .ingredient(A, 1)
+            .output(B, 1)
+            .build());
+        inputAutocrafting.onContainerAdded(() -> patternProvider);
+
+        outputStorage.addSource(new StorageImpl());
+        outputStorage.insert(A, 10, Action.EXECUTE, Actor.EMPTY);
+
+        input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
+
+        assertThat(outputAutocrafting.startTask(B, 10, Actor.EMPTY, false).join()).isPresent();
+
+        // Act & assert
+        output.doWork();
+        assertThat(output.getTasks()).hasSize(1);
+
+        output.doWork();
+        assertThat(output.getTasks()).hasSize(1);
+        assertThat(outputStorage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+            new ResourceAmount(B, 1)
+        );
+
+        output.setStepBehavior(new StepBehavior() {
+            @Override
+            public int getSteps(final Pattern pattern) {
+                return 9;
+            }
+        });
+
+        output.doWork();
+        assertThat(output.getTasks()).isEmpty();
+        assertThat(outputStorage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+            new ResourceAmount(B, 10)
+        );
+    }
+
+    @Test
+    void shouldStepTasksWithExternalPattern(
+        @InjectNetworkAutocraftingComponent(networkId = "input") final AutocraftingNetworkComponent inputAutocrafting,
+        @InjectNetworkAutocraftingComponent(networkId = "output") final AutocraftingNetworkComponent outputAutocrafting,
+        @InjectNetworkStorageComponent(networkId = "input") final StorageNetworkComponent inputStorage,
+        @InjectNetworkStorageComponent(networkId = "output") final StorageNetworkComponent outputStorage
+    ) {
+        // Arrange
+        input.setActive(true);
+        input.setOutputNode(output);
+        inputStorage.addSource(new StorageImpl());
+
+        final PatternProviderNetworkNode patternProvider = new PatternProviderNetworkNode(0, 1);
+        patternProvider.setPattern(0, pattern(PatternType.EXTERNAL)
+            .ingredient(A, 1)
+            .output(B, 1)
+            .build());
+        final PatternProviderListener listener = mock(PatternProviderListener.class);
+        final PatternProviderExternalPatternSinkImpl sink = new PatternProviderExternalPatternSinkImpl();
+        patternProvider.setSink(sink);
+        patternProvider.setListener(listener);
+        inputAutocrafting.onContainerAdded(() -> patternProvider);
+
+        outputStorage.addSource(new StorageImpl());
+        outputStorage.insert(A, 2, Action.EXECUTE, Actor.EMPTY);
+
+        input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
+
+        assertThat(outputAutocrafting.startTask(B, 2, Actor.EMPTY, false).join()).isPresent();
+
+        // Act & assert
+        output.doWork();
+        assertThat(output.getTasks()).hasSize(1);
+        assertThat(outputStorage.getAll()).isEmpty();
+        assertThat(sink.getAll()).isEmpty();
+
+        output.doWork();
+        assertThat(output.getTasks()).hasSize(1);
+        assertThat(outputStorage.getAll()).isEmpty();
+        assertThat(sink.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+            new ResourceAmount(A, 1)
+        );
+
+        output.doWork();
+        assertThat(output.getTasks()).hasSize(1);
+        assertThat(outputStorage.getAll()).isEmpty();
+        assertThat(sink.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+            new ResourceAmount(A, 2)
+        );
+
+        inputStorage.insert(B, 2, Action.EXECUTE, Actor.EMPTY);
+        output.doWork();
+        assertThat(output.getTasks()).hasSize(1);
+        assertThat(outputStorage.getAll()).isEmpty();
+        assertThat(sink.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+            new ResourceAmount(A, 2)
+        );
+
+        outputStorage.insert(B, 2, Action.EXECUTE, Actor.EMPTY);
+        output.doWork();
+        verify(listener, times(1)).receivedExternalIteration();
+        assertThat(output.getTasks()).isEmpty();
+        assertThat(outputStorage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+            new ResourceAmount(B, 2)
+        );
+        assertThat(sink.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+            new ResourceAmount(A, 2)
+        );
+    }
+
+    @Nested
+    @SetupNetwork(id = "output2")
+    class NetworkChangeTest {
+        @Test
+        void shouldInterceptInsertionsOnNewNetworkWhenNetworkChanges(
+            @InjectNetworkAutocraftingComponent(networkId = "input")
+            final AutocraftingNetworkComponent inputAutocrafting,
+            @InjectNetworkAutocraftingComponent(networkId = "output")
+            final AutocraftingNetworkComponent outputAutocrafting,
+            @InjectNetworkStorageComponent(networkId = "input") final StorageNetworkComponent inputStorage,
+            @InjectNetworkStorageComponent(networkId = "output") final StorageNetworkComponent outputStorage,
+            @InjectNetwork("output2") final Network outputNetwork2,
+            @InjectNetworkStorageComponent(networkId = "output2") final StorageNetworkComponent outputStorage2
+        ) {
+            // Arrange
+            input.setActive(true);
+            input.setOutputNode(output);
+            inputStorage.addSource(new StorageImpl());
+
+            final PatternProviderNetworkNode patternProvider = new PatternProviderNetworkNode(0, 1);
+            patternProvider.setPattern(0, pattern(PatternType.EXTERNAL)
+                .ingredient(A, 1)
+                .output(B, 1)
+                .build());
+            final PatternProviderExternalPatternSinkImpl sink = new PatternProviderExternalPatternSinkImpl();
+            patternProvider.setSink(sink);
+            inputAutocrafting.onContainerAdded(() -> patternProvider);
+
+            outputStorage.addSource(new StorageImpl());
+            outputStorage.insert(A, 2, Action.EXECUTE, Actor.EMPTY);
+
+            input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
+
+            assertThat(outputAutocrafting.startTask(B, 2, Actor.EMPTY, false).join()).isPresent();
+
+            // Act & assert
+            output.doWork();
+            assertThat(output.getTasks()).hasSize(1);
+            assertThat(outputStorage.getAll()).isEmpty();
+            assertThat(sink.getAll()).isEmpty();
+
+            output.doWork();
+            assertThat(output.getTasks()).hasSize(1);
+            assertThat(sink.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+                new ResourceAmount(A, 1)
+            );
+
+            output.doWork();
+            assertThat(output.getTasks()).hasSize(1);
+            assertThat(sink.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+                new ResourceAmount(A, 2)
+            );
+
+            outputStorage.insert(B, 1, Action.EXECUTE, Actor.EMPTY);
+            output.doWork();
+            assertThat(output.getTasks()).hasSize(1);
+
+            output.setNetwork(outputNetwork2);
+            outputNetwork2.addContainer(() -> output);
+
+            outputStorage.insert(B, 1, Action.EXECUTE, Actor.EMPTY);
+            output.doWork();
+            assertThat(output.getTasks()).hasSize(1);
+
+            outputStorage2.insert(B, 1, Action.EXECUTE, Actor.EMPTY);
+            output.doWork();
+            assertThat(output.getTasks()).isEmpty();
+        }
+
+        @Test
+        void shouldNotifyStatusListenersOfOldAndNewNetworkWhenNetworkChanges(
+            @InjectNetworkAutocraftingComponent(networkId = "input")
+            final AutocraftingNetworkComponent inputAutocrafting,
+            @InjectNetworkAutocraftingComponent(networkId = "output")
+            final AutocraftingNetworkComponent outputAutocrafting,
+            @InjectNetworkAutocraftingComponent(networkId = "output2")
+            final AutocraftingNetworkComponent outputAutocrafting2,
+            @InjectNetworkStorageComponent(networkId = "output") final StorageNetworkComponent outputStorage,
+            @InjectNetwork("output") final Network outputNetwork,
+            @InjectNetwork("output2") final Network outputNetwork2
+        ) {
+            // Arrange
+            final TaskStatusListener listener = mock(TaskStatusListener.class);
+            outputAutocrafting.addListener(listener);
+
+            final TaskStatusListener listener2 = mock(TaskStatusListener.class);
+            outputAutocrafting2.addListener(listener2);
+
+            outputStorage.addSource(new StorageImpl());
+            outputStorage.insert(A, 10, Action.EXECUTE, Actor.EMPTY);
+
+            final PatternProviderNetworkNode patternProvider = new PatternProviderNetworkNode(0, 1);
+            patternProvider.setPattern(0, pattern().ingredient(A, 1).output(B, 1).build());
+            inputAutocrafting.onContainerAdded(() -> patternProvider);
+
+            input.setActive(true);
+            input.setOutputNode(output);
+            input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
+
+            // Act & assert
+            final var taskId = outputAutocrafting.startTask(B, 1, Actor.EMPTY, false).join();
+            assertThat(taskId).isPresent();
+            final ArgumentCaptor<TaskStatus> statusCaptor = ArgumentCaptor.forClass(TaskStatus.class);
+            verify(listener, times(1)).taskAdded(statusCaptor.capture());
+            verify(listener, never()).taskRemoved(any());
+            verify(listener2, never()).taskAdded(any());
+            verify(listener2, never()).taskRemoved(any());
+            final TaskStatus status = statusCaptor.getValue();
+            assertThat(status.info().id()).isEqualTo(taskId.get());
+
+            reset(listener, listener2);
+
+            outputNetwork.removeContainer(() -> output);
+            output.setNetwork(outputNetwork2);
+            outputNetwork2.addContainer(() -> output);
+
+            verify(listener, never()).taskAdded(any());
+            final ArgumentCaptor<TaskId> removedIdCaptor = ArgumentCaptor.forClass(TaskId.class);
+            verify(listener, times(1)).taskRemoved(removedIdCaptor.capture());
+            final ArgumentCaptor<TaskStatus> addedTaskCaptor = ArgumentCaptor.forClass(TaskStatus.class);
+            verify(listener2, times(1)).taskAdded(addedTaskCaptor.capture());
+            verify(listener2, never()).taskRemoved(any());
+        }
+
+        @Test
+        void shouldBeAbleToCancelTaskInNewNetworkWhenNetworkChanges(
+            @InjectNetworkAutocraftingComponent(networkId = "input")
+            final AutocraftingNetworkComponent inputAutocrafting,
+            @InjectNetworkAutocraftingComponent(networkId = "output")
+            final AutocraftingNetworkComponent outputAutocrafting,
+            @InjectNetworkAutocraftingComponent(networkId = "output2")
+            final AutocraftingNetworkComponent outputAutocrafting2,
+            @InjectNetworkStorageComponent(networkId = "output") final StorageNetworkComponent outputStorage,
+            @InjectNetwork("output") final Network outputNetwork,
+            @InjectNetwork("output2") final Network outputNetwork2
+        ) {
+            // Arrange
+            final TaskStatusListener listener = mock(TaskStatusListener.class);
+            outputAutocrafting.addListener(listener);
+
+            final TaskStatusListener listener2 = mock(TaskStatusListener.class);
+            outputAutocrafting2.addListener(listener2);
+
+            outputStorage.addSource(new StorageImpl());
+            outputStorage.insert(A, 10, Action.EXECUTE, Actor.EMPTY);
+
+            final PatternProviderNetworkNode patternProvider = new PatternProviderNetworkNode(0, 1);
+            patternProvider.setPattern(0, pattern().ingredient(A, 1).output(B, 1).build());
+            inputAutocrafting.onContainerAdded(() -> patternProvider);
+
+            input.setActive(true);
+            input.setOutputNode(output);
+            input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
+
+            // Act & assert
+            final var taskId = outputAutocrafting.startTask(B, 1, Actor.EMPTY, false).join();
+            assertThat(taskId).isPresent();
+            assertThat(output.getTasks()).hasSize(1).allMatch(t -> t.getState() == TaskState.READY);
+
+            outputNetwork.removeContainer(() -> output);
+            output.setNetwork(outputNetwork2);
+            outputNetwork2.addContainer(() -> output);
+
+            outputAutocrafting.cancel(taskId.get());
+            assertThat(output.getTasks()).hasSize(1).allMatch(t -> t.getState() == TaskState.READY);
+
+            outputAutocrafting2.cancel(taskId.get());
+            assertThat(output.getTasks()).hasSize(1)
+                .allMatch(t -> t.getState() == TaskState.RETURNING_INTERNAL_STORAGE);
+        }
     }
 }


### PR DESCRIPTION
You can now start tasks in the output network,
using patterns and autocrafters from the input network.

Fixes #612 