### PR TITLE
fix: fluid amount is to the millibucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 -   The filter slots for the Exporter, Constructor and Interface now display whether a resource is missing, the destination does not accept it, the resource cannot be autocrafted due to missing resources, or whether the resource is currently autocrafting.
+-   Fluids display in millibuckets (mb) if less than a bucket, and append 'b' to signify bucket unit.
+-   Item and fluid counts are in small font.
+
+### Fixed 
+-   Fluids display 3 decimal places in tooltip
+-   Fixed autocrafting request and pattern set amount screens allow for less than 1 bucket.
 
 ## [2.0.0-milestone.4.13] - 2025-02-01
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/patterngrid/AlternativesScreen.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/patterngrid/AlternativesScreen.java
@@ -91,7 +91,7 @@ public class AlternativesScreen extends AbstractAmountScreen<AlternativeContaine
                 .withAmountFieldPosition(new Vector3f(47, 51, 0))
                 .withActionButtonsStartPosition(new Vector3f(7, 199, 0))
                 .withHorizontalActionButtons(true)
-                .withMinAmount(1D)
+                .withMinAmount(0D)
                 .withMaxAmount(slot.getMaxAmountWhenModifying())
                 .withResetAmount(1D)
                 .build(),

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/preview/AutocraftingPreviewScreen.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/preview/AutocraftingPreviewScreen.java
@@ -136,7 +136,7 @@ public class AutocraftingPreviewScreen extends AbstractAmountScreen<Autocrafting
                 .withAmountFieldPosition(new Vector3f(77, 51, 0))
                 .withActionButtonsStartPosition(new Vector3f(7, 222, 0))
                 .withHorizontalActionButtons(true)
-                .withMinAmount(1D)
+                .withMinAmount(0D)
                 .withResetAmount(1D)
                 .withConfirmButtonText(START)
                 .build(),

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/ResourceSlotRendering.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/ResourceSlotRendering.java
@@ -56,7 +56,7 @@ public final class ResourceSlotRendering {
             y,
             rendering.formatAmount(amount, true),
             0xFFFFFF,
-            true
+            false
         );
     }
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/amount/ResourceAmountScreen.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/amount/ResourceAmountScreen.java
@@ -34,7 +34,7 @@ public class ResourceAmountScreen
                 .withIncrementsBottomStartPosition(new Vector3f(7, 72, 0))
                 .withAmountFieldPosition(new Vector3f(9, 51, 0))
                 .withActionButtonsStartPosition(new Vector3f(114, 22, 0))
-                .withMinAmount(1D)
+                .withMinAmount(0D)
                 .withMaxAmount(slot.getMaxAmountWhenModifying())
                 .withResetAmount(1D)
                 .build(),

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/resource/FluidResourceRendering.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/resource/FluidResourceRendering.java
@@ -18,12 +18,8 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
 
 public class FluidResourceRendering implements ResourceRendering {
-    private static final DecimalFormat LESS_THAN_1_BUCKET_FORMATTER = new DecimalFormat(
-        "0.#",
-        DecimalFormatSymbols.getInstance(Locale.US)
-    );
     private static final DecimalFormat FORMATTER = new DecimalFormat(
-        "#,###.#",
+        "#,###.###",
         DecimalFormatSymbols.getInstance(Locale.US)
     );
 
@@ -79,11 +75,7 @@ public class FluidResourceRendering implements ResourceRendering {
 
     private static String formatWithUnits(final long droplets, final long bucketAmount) {
         final double buckets = convertToBuckets(droplets, bucketAmount);
-        if (buckets >= 1) {
-            return IdentifierUtil.formatWithUnits((long) Math.floor(buckets));
-        } else {
-            return LESS_THAN_1_BUCKET_FORMATTER.format(buckets);
-        }
+        return IdentifierUtil.formatWithUnits(buckets) + "b";
     }
 
     private static String format(final long droplets, final long bucketAmount) {

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/util/IdentifierUtil.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/util/IdentifierUtil.java
@@ -88,29 +88,35 @@ public final class IdentifierUtil {
         return prefix + id.getNamespace() + "." + fixedPath;
     }
 
-    public static String formatWithUnits(final long qty) {
+    public static String formatWithUnits(final double qty) {
         if (qty >= 1_000_000_000) {
-            return formatBillion(qty);
+            return formatBillion((long) qty);
         } else if (qty >= 1_000_000) {
-            return formatMillion(qty);
+            return formatMillion((long) qty);
         } else if (qty >= 1000) {
-            return formatThousand(qty);
+            return formatThousand((long) qty);
+        } else if (qty < 1) {
+            return formatThousandth(qty);
         }
-        return String.valueOf(qty);
+        return String.valueOf((long) qty);
     }
 
-    private static String formatBillion(final long qty) {
+    private static String formatThousandth(final double qty) {
+        return FORMATTER_WITH_UNITS.format(qty * 1_000) + "m";
+    }
+
+    private static String formatBillion(final double qty) {
         return FORMATTER_WITH_UNITS.format(qty / 1_000_000_000D) + "B";
     }
 
-    private static String formatMillion(final long qty) {
+    private static String formatMillion(final double qty) {
         if (qty >= 100_000_000) {
             return FORMATTER_WITH_UNITS.format(Math.floor(qty / 1_000_000D)) + "M";
         }
         return FORMATTER_WITH_UNITS.format(qty / 1_000_000D) + "M";
     }
 
-    private static String formatThousand(final long qty) {
+    private static String formatThousand(final double qty) {
         if (qty >= 100_000) {
             return FORMATTER_WITH_UNITS.format(Math.floor(qty / 1000D)) + "K";
         }


### PR DESCRIPTION
see #805 
fix: allow autocrafting less than a bucket of fluid
fix: item amounts in pattern creation, autocraft monitor, and pattern item tooltip are small size
Refactor:  formatWithUnits parameter qty long to double and add formatThousandth method to format 0.16 buckets as 160m (other functions are not affected, since long is implicitly converted to double)
fix: Fluids displays to 3 decimal places
feat: Fluid renderer appends b after amount to signify bucket