### PR TITLE
fix: pattern grid dropping items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -   Fixed item count rendering behind the item in the Interface slots.
 -   Fixed pickaxes not influencing break speed of blocks.
 -   Fixed non-autocraftables Grid view filter still showing autocraftable resources as they get inserted.
+-   Fixed pattern grid dropping items for pattern
+-   Fixed pattern dropped from broken pattern grid
 -   Fixed autocrafting tasks being completed when not all processing outputs have been received yet.
 -   Fixed items not stacking when externally interacting with an Interface.
 -   Fixed Constructor in default scheduling mode not trying other filters when resource is not available.

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/patterngrid/PatternGridBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/patterngrid/PatternGridBlockEntity.java
@@ -254,9 +254,6 @@ public class PatternGridBlockEntity extends AbstractGridBlockEntity implements B
         final NonNullList<ItemStack> drops = NonNullList.create();
         drops.add(patternInput.getItem(0));
         drops.add(patternOutput.getItem(0));
-        for (int i = 0; i < craftingRecipe.getMatrix().getContainerSize(); ++i) {
-            drops.add(craftingRecipe.getMatrix().getItem(i));
-        }
         return drops;
     }
 


### PR DESCRIPTION
fix #851 
Changed crafting grid to put back the items into storage when broken