### PR TITLE
chore: ordered tooltips for upgrade slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 -   The External Storage now supports multiple resource types on a single connected inventory.
+-   Tooltips for upgrade slots are now ordered.
 
 ### Fixed
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/upgrade/UpgradeRegistryImpl.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/upgrade/UpgradeRegistryImpl.java
@@ -6,7 +6,7 @@ import com.refinedmods.refinedstorage.common.api.upgrade.UpgradeRegistry;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -23,8 +23,8 @@ public class UpgradeRegistryImpl implements UpgradeRegistry {
             @Override
             public DestinationBuilder add(final Item upgradeItem, final int maxAmount) {
                 final UpgradeMapping mapping = createMapping(destination, upgradeItem, maxAmount);
-                byDestination.computeIfAbsent(destination, key -> new HashSet<>()).add(mapping);
-                byUpgradeItem.computeIfAbsent(upgradeItem, key -> new HashSet<>()).add(mapping);
+                byDestination.computeIfAbsent(destination, key -> new LinkedHashSet<>()).add(mapping);
+                byUpgradeItem.computeIfAbsent(upgradeItem, key -> new LinkedHashSet<>()).add(mapping);
                 return this;
             }
         };


### PR DESCRIPTION
The order of the tooltips for the upgrade slots now follows the order in which they were specified in the AbstractModInitializer class

Refs: #883