### PR TITLE
Fix #952: Preserve order of resources in PatternProviderSink

### DIFF
--- a/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/autocrafting/ItemHandlerExternalPatternProviderSink.java
+++ b/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/autocrafting/ItemHandlerExternalPatternProviderSink.java
@@ -82,7 +82,9 @@ class ItemHandlerExternalPatternProviderSink implements PlatformPatternProviderE
     }
 
     private static ArrayDeque<ItemStack> getStacks(final Collection<ResourceAmount> resources) {
-        // Create a new ArrayList to preserve the original order from the pattern
+        // Create a new ArrayList to preserve the original order from the pattern.
+        // A for-loop is used here instead of stream processing to ensure clarity and 
+        // explicitly preserve the order of resources as they are processed.
         List<ItemStack> orderedStacks = new ArrayList<>();
         
         for (ResourceAmount resourceAmount : resources) {

--- a/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/autocrafting/ItemHandlerExternalPatternProviderSink.java
+++ b/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/autocrafting/ItemHandlerExternalPatternProviderSink.java
@@ -11,6 +11,7 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -81,12 +82,17 @@ class ItemHandlerExternalPatternProviderSink implements PlatformPatternProviderE
     }
 
     private static ArrayDeque<ItemStack> getStacks(final Collection<ResourceAmount> resources) {
-        return new ArrayDeque<>(resources.stream()
-            .filter(resourceAmount -> resourceAmount.resource() instanceof ItemResource)
-            .map(resourceAmount -> {
+        // Create a new ArrayList to preserve the original order from the pattern
+        List<ItemStack> orderedStacks = new ArrayList<>();
+        
+        for (ResourceAmount resourceAmount : resources) {
+            if (resourceAmount.resource() instanceof ItemResource) {
                 final ItemResource itemResource = (ItemResource) resourceAmount.resource();
-                return itemResource.toItemStack(resourceAmount.amount());
-            }).toList());
+                orderedStacks.add(itemResource.toItemStack(resourceAmount.amount()));
+            }
+        }
+        
+        return new ArrayDeque<>(orderedStacks);
     }
 
     @Override

--- a/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/OrderPreservingMutableResourceListImplTest.java
+++ b/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/OrderPreservingMutableResourceListImplTest.java
@@ -22,22 +22,22 @@ class OrderPreservingMutableResourceListImplTest extends AbstractMutableResource
     @Test
     void shouldPreserveOrderWhenRetrievingKeys() {
         // Arrange
-        sut.add(A, 1);
         sut.add(B, 1);
+        sut.add(A, 2);
         sut.add(C, 1);
 
         // Act
         final Set<ResourceKey> resources = sut.getAll();
 
         // Assert
-        assertThat(resources).containsExactly(A, B, C);
+        assertThat(resources).containsExactly(B, A, C);
     }
 
     @Test
     void shouldPreserveOrderWhenCopyingState() {
         // Arrange
-        sut.add(A, 1);
         sut.add(B, 1);
+        sut.add(A, 2);
         sut.add(C, 1);
 
         // Act
@@ -45,8 +45,8 @@ class OrderPreservingMutableResourceListImplTest extends AbstractMutableResource
 
         // Assert
         assertThat(resources).usingRecursiveFieldByFieldElementComparator().containsExactly(
-            new ResourceAmount(A, 1),
             new ResourceAmount(B, 1),
+            new ResourceAmount(A, 2),
             new ResourceAmount(C, 1)
         );
     }

--- a/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/OrderPreservingMutableResourceListImplTest.java
+++ b/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/OrderPreservingMutableResourceListImplTest.java
@@ -30,6 +30,7 @@ class OrderPreservingMutableResourceListImplTest extends AbstractMutableResource
         final Set<ResourceKey> resources = sut.getAll();
 
         // Assert
+        // The expected order of keys is B, A, C, as the list preserves the order of addition.
         assertThat(resources).containsExactly(B, A, C);
     }
 


### PR DESCRIPTION
Ensure that the order of resources is maintained when retrieving keys and copying state in the PatternProviderSink. This change modifies the way resources are collected to respect their original order.