### PR TITLE
Fix #997 - Check for amount of fluid being greater than zero

### DIFF
--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/resource/ResourceContainerImpl.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/resource/ResourceContainerImpl.java
@@ -293,7 +293,7 @@ public class ResourceContainerImpl implements ResourceContainer {
 
     @Override
     public long insert(final ResourceKey resource, final long amount, final Action action) {
-        if (!(resource instanceof PlatformResourceKey platformResource)) {
+        if (!(resource instanceof PlatformResourceKey platformResource) || amount <= 0) {
             return 0L;
         }
         long remainder = amount;

--- a/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/storage/FluidHandlerInsertableStorage.java
+++ b/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/storage/FluidHandlerInsertableStorage.java
@@ -30,9 +30,10 @@ public class FluidHandlerInsertableStorage implements InsertableStorage {
 
     @Override
     public long insert(final ResourceKey resource, final long amount, final Action action, final Actor actor) {
-        if (!(resource instanceof FluidResource fluidResource)) {
+        if (!(resource instanceof FluidResource fluidResource) || amount <= 0) {
             return 0;
         }
+
         return capabilityCache.getFluidHandler()
             .map(fluidHandler -> insert(fluidResource, amount, action, fluidHandler))
             .orElse(0L);

--- a/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/support/resource/ResourceContainerFluidHandlerAdapter.java
+++ b/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/support/resource/ResourceContainerFluidHandlerAdapter.java
@@ -52,6 +52,10 @@ public class ResourceContainerFluidHandlerAdapter implements IFluidHandler {
 
     @Override
     public int fill(final FluidStack resource, final FluidAction action) {
+        if (resource.getAmount() <= 0) {
+            return 0;
+        }
+
         return (int) container.insert(ofFluidStack(resource), resource.getAmount(), toAction(action));
     }
 


### PR DESCRIPTION
Closes #997

When fluids are being put into the network, there are no checks to see if the fluid amount is greater than zero. When they are zero (which can be the case with some mod pack pipes) it causes an IllegalArgumentException to bubble up and cause the server to perpetually crash.

I have built the JAR and loaded it into our server and this resolved the crashing.