### PR TITLE
fix: network transmitter not reconnecting after network change on oth…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 -  Fixed crash when closing a Wireless Grid that became available after opening the GUI.
+-  Fixed networks breaking when modifying the receiving end when using Network Transmitters and Network Receivers.
 
 ## [2.0.0-beta.6] - 2025-08-03
 

--- a/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/debug/NetworkDebugRenderer.java
+++ b/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/debug/NetworkDebugRenderer.java
@@ -200,7 +200,7 @@ public final class NetworkDebugRenderer {
 
     private static int getColorFromId(final int id) {
         if (id == -1) {
-            return 0x00000000;
+            return 0xFF000000;
         }
         final byte[] hash = getIdHash(id);
         final int r = Byte.toUnsignedInt(hash[0]);

--- a/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/NetworkBuilderImpl.java
+++ b/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/NetworkBuilderImpl.java
@@ -75,6 +75,9 @@ public class NetworkBuilderImpl implements NetworkBuilder {
                                        final NetworkNode entryNode) {
         final Network oldNetwork = entryNode.getNetwork();
         entryNode.setNetwork(newNetwork);
+        if (oldNetwork != null) {
+            oldNetwork.removeContainer(entry);
+        }
         newNetwork.addContainer(entry);
         return oldNetwork;
     }

--- a/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/ConnectionProviderImpl.java
+++ b/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/ConnectionProviderImpl.java
@@ -42,6 +42,14 @@ public class ConnectionProviderImpl implements ConnectionProvider {
         return this;
     }
 
+    public ConnectionProviderImpl connectOneway(final NetworkNodeContainer from, final NetworkNodeContainer to) {
+        if (!allowed.contains(from) || !allowed.contains(to)) {
+            throw new IllegalArgumentException();
+        }
+        doConnect(from, to);
+        return this;
+    }
+
     private void doConnect(final NetworkNodeContainer from, final NetworkNodeContainer to) {
         connections.computeIfAbsent(from, k -> new ArrayList<>()).add(to);
     }

--- a/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/InitializeNetworkBuilderImplTest.java
+++ b/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/InitializeNetworkBuilderImplTest.java
@@ -212,4 +212,39 @@ class InitializeNetworkBuilderImplTest extends AbstractNetworkBuilderImplTest {
             unrelatedContainer.getNode().getNetwork().getComponent(GraphNetworkComponent.class).getContainers())
             .containsExactly(unrelatedContainer);
     }
+
+    @Test
+    void shouldRemoveFromOldNetworkWhenMerging() {
+        // Arrange
+        final ConnectionProviderImpl connectionProvider = new ConnectionProviderImpl();
+
+        final NetworkNodeContainer left = createContainerWithNetwork();
+        final NetworkNodeContainer right =
+            createContainerWithNetwork(container -> left.getNode().getNetwork());
+
+        final NetworkNodeContainer otherCausingOverrideOfRightNetwork = createContainerWithNetwork();
+
+        final NetworkNodeContainer connecting = createContainer();
+
+        connectionProvider
+            .with(otherCausingOverrideOfRightNetwork, left, right, connecting)
+            .connectOneway(left, right)
+            .connect(right, connecting)
+            .connect(connecting, otherCausingOverrideOfRightNetwork);
+
+        // Act
+        sut.initialize(connecting, connectionProvider);
+
+        // Assert
+        assertThat(right.getNode().getNetwork())
+            .isSameAs(otherCausingOverrideOfRightNetwork.getNode().getNetwork())
+            .isSameAs(connecting.getNode().getNetwork())
+            .isNotSameAs(left.getNode().getNetwork());
+
+        assertThat(right.getNode().getNetwork().getComponent(GraphNetworkComponent.class).getContainers())
+            .containsExactlyInAnyOrder(right, otherCausingOverrideOfRightNetwork, connecting);
+
+        assertThat(left.getNode().getNetwork().getComponent(GraphNetworkComponent.class).getContainers())
+            .containsExactly(left);
+    }
 }

--- a/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/PriorityNetworkBuilderImplTest.java
+++ b/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/PriorityNetworkBuilderImplTest.java
@@ -18,6 +18,7 @@ import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 import static com.refinedmods.refinedstorage.api.network.impl.PriorityNetworkBuilderImplTest.MasterSlave.MASTER;
 import static com.refinedmods.refinedstorage.api.network.impl.PriorityNetworkBuilderImplTest.MasterSlave.SLAVE;
@@ -93,18 +94,24 @@ class PriorityNetworkBuilderImplTest extends AbstractNetworkBuilderImplTest {
         assertThat(slave.nodeA.getNetwork()).isSameAs(master.nodeA.getNetwork());
         assertThat(slave.nodeB.getNetwork()).isSameAs(master.nodeA.getNetwork());
 
-        verify(slave.watcher, times(1)).invalidate();
-        verify(slave.watcher).onChanged(
+        final InOrder inOrder = Mockito.inOrder(slave.watcher);
+        inOrder.verify(slave.watcher).onChanged(
             SLAVE,
-            10L,
+            -10L,
             null
         );
-        verify(slave.watcher).onChanged(
+        inOrder.verify(slave.watcher, times(1)).invalidate();
+        inOrder.verify(slave.watcher).onChanged(
             MASTER,
             10L,
             null
         );
-        verifyNoMoreInteractions(slave.watcher);
+        inOrder.verify(slave.watcher).onChanged(
+            SLAVE,
+            10L,
+            null
+        );
+        inOrder.verifyNoMoreInteractions();
 
         verify(master.watcher, times(1)).onChanged(
             SLAVE,


### PR DESCRIPTION
…er side

A merge on the receiver side could override the network on the receiver side, but not the transmitting side (because it is one-way).
However, nodes would linger
in the graph of the transmitting
side.
Because of this, the transmitter
was not reconnecting with the
receiving side because the receiver node
is still in the graph, even
if it has another network.

This messes up the graph, and causes
problems and exceptions later down the line
(not further investigated.)

No clue why the watcher changes
were necessary, but after
some tests the grids still behave
correctly with merges.

Fixes #949