### PR TITLE
fix: crash when rotating relays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -  Fixed crash when closing a Wireless Grid that became available after opening the GUI.
 -  Fixed networks breaking when modifying the receiving end when using Network Transmitters and Network Receivers.
+-  Rotating Relays was disabled since v2.0.0-milestone.4.14 because of a crash. This crash has now been fixed and Relays can once again be rotated.
 
 ## [2.0.0-beta.6] - 2025-08-03
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/RelayBlock.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/RelayBlock.java
@@ -40,11 +40,6 @@ public class RelayBlock extends AbstractActiveColoredDirectionalBlock<Direction,
         super(BlockConstants.PROPERTIES, color, name);
     }
 
-    @SuppressWarnings("deprecation") // deprecated on NeoForge
-    protected BlockState getRotatedBlockState(final BlockState state, final Level level, final BlockPos pos) {
-        return state;
-    }
-
     @Nullable
     @Override
     public BlockEntity newBlockEntity(final BlockPos blockPos, final BlockState blockState) {

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/RelayBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/RelayBlockEntity.java
@@ -12,6 +12,7 @@ import com.refinedmods.refinedstorage.common.api.support.network.InWorldNetworkN
 import com.refinedmods.refinedstorage.common.content.BlockEntities;
 import com.refinedmods.refinedstorage.common.content.ContentNames;
 import com.refinedmods.refinedstorage.common.storage.AccessModeSettings;
+import com.refinedmods.refinedstorage.common.support.AbstractDirectionalBlock;
 import com.refinedmods.refinedstorage.common.support.FilterModeSettings;
 import com.refinedmods.refinedstorage.common.support.FilterWithFuzzyMode;
 import com.refinedmods.refinedstorage.common.support.RedstoneMode;
@@ -298,5 +299,11 @@ public class RelayBlockEntity extends AbstractBaseNetworkNodeContainerBlockEntit
             types.add(RelayComponentType.AUTOCRAFTING);
         }
         return types;
+    }
+
+    @Override
+    protected boolean doesBlockStateChangeWarrantNetworkNodeUpdate(final BlockState oldBlockState,
+                                                                   final BlockState newBlockState) {
+        return AbstractDirectionalBlock.didDirectionChange(oldBlockState, newBlockState);
     }
 }


### PR DESCRIPTION
The real fix for this crash is present in
8eab53fa.

So now, make sure that we can rotate
them again (disabled since c6bd3bc4)

We do need to trigger a network update
after rotating, though (this was missing
before too).

Fixes #850