### PR TITLE
fix: show correct drain amount on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 -   Duplication bug with Inventory Essentials.
+-   Incorrect extractable amount shown when hovering over a fluid tank in the Grid.
 
 ## [2.0.0-beta.9] - 2025-08-15
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/screen/hint/FluidGridInsertionHint.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/screen/hint/FluidGridInsertionHint.java
@@ -19,11 +19,12 @@ public class FluidGridInsertionHint implements GridInsertionHint {
     }
 
     private ClientTooltipComponent createComponent(final FluidOperationResult result) {
+        final long amount = Math.min(result.amount(), Platform.INSTANCE.getBucketAmount());
         return MouseClientTooltipComponent.fluid(
             MouseClientTooltipComponent.Type.RIGHT,
             (FluidResource) result.fluid(),
-            result.amount() == Platform.INSTANCE.getBucketAmount() ? null : RefinedStorageClientApi.INSTANCE
-                .getResourceRendering(FluidResource.class).formatAmount(result.amount())
+            amount == Platform.INSTANCE.getBucketAmount() ? null : RefinedStorageClientApi.INSTANCE
+                .getResourceRendering(FluidResource.class).formatAmount(amount)
         );
     }
 }


### PR DESCRIPTION
When hovering over a fluid tank that can extract more than one bucket of fluid, the tooltip displays a different amount than what is actually drained when right-clicking. Regardless of the tooltip value, right-clicking always drains exactly one full bucket.

<img width="1920" height="1080" alt="2025-08-10_20 12 22" src="https://github.com/user-attachments/assets/f71ccdc8-6ef3-40f7-894d-f596631862d8" />
