### PR TITLE
fix: wrong insertion order for processing ingredients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -   Duplication bug with Inventory Essentials.
 -   Incorrect extractable amount shown when hovering over a fluid tank in the Grid.
 -   Crash when crafting tree preview is requested and the same resource amount is being used over multiple branches.
+-   Fixed processing patterns inserting ingredients in the wrong order into machines.
 
 ## [2.0.0-beta.9] - 2025-08-15
 

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/AbstractTaskPattern.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/AbstractTaskPattern.java
@@ -9,7 +9,6 @@ import com.refinedmods.refinedstorage.api.resource.list.MutableResourceListImpl;
 import com.refinedmods.refinedstorage.api.resource.list.ResourceList;
 import com.refinedmods.refinedstorage.api.storage.root.RootStorage;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -21,7 +20,7 @@ abstract class AbstractTaskPattern {
 
     protected final boolean root;
     protected final Pattern pattern;
-    protected final Map<Integer, Map<ResourceKey, Long>> ingredients = new HashMap<>();
+    protected final Map<Integer, Map<ResourceKey, Long>> ingredients = new LinkedHashMap<>();
 
     protected AbstractTaskPattern(final Pattern pattern, final TaskPlan.PatternPlan plan) {
         this.pattern = pattern;
@@ -63,7 +62,7 @@ abstract class AbstractTaskPattern {
     }
 
     protected final ResourceList calculateIterationInputs(final Action action) {
-        final MutableResourceList iterationInputs = MutableResourceListImpl.create();
+        final MutableResourceList iterationInputs = MutableResourceListImpl.orderPreserving();
         for (final Map.Entry<Integer, Map<ResourceKey, Long>> ingredient : ingredients.entrySet()) {
             final int ingredientIndex = ingredient.getKey();
             if (!calculateIterationInputs(ingredient, ingredientIndex, iterationInputs, action)) {

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/MutablePatternPlan.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/MutablePatternPlan.java
@@ -43,8 +43,8 @@ class MutablePatternPlan {
     }
 
     TaskPlan.PatternPlan getPlan() {
-        return new TaskPlan.PatternPlan(root, iterations, ingredients.entrySet().stream()
-            .collect(Collectors.toUnmodifiableMap(
+        final Map<Integer, Map<ResourceKey, Long>> orderPreservingIngredients =
+            Collections.unmodifiableMap(ingredients.entrySet().stream().collect(Collectors.toMap(
                 Map.Entry::getKey,
                 e -> Collections.unmodifiableMap(e.getValue()
                     .entrySet()
@@ -54,7 +54,10 @@ class MutablePatternPlan {
                         Map.Entry::getValue,
                         (a, b) -> a,
                         LinkedHashMap::new
-                    )))
+                    ))),
+                (a, b) -> a,
+                LinkedHashMap::new
             )));
+        return new TaskPlan.PatternPlan(root, iterations, orderPreservingIngredients);
     }
 }

--- a/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/task/ExternalPatternSinkProviderImpl.java
+++ b/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/task/ExternalPatternSinkProviderImpl.java
@@ -4,6 +4,7 @@ import com.refinedmods.refinedstorage.api.autocrafting.Pattern;
 import com.refinedmods.refinedstorage.api.autocrafting.PatternLayout;
 import com.refinedmods.refinedstorage.api.core.Action;
 import com.refinedmods.refinedstorage.api.resource.ResourceAmount;
+import com.refinedmods.refinedstorage.api.resource.list.MutableResourceListImpl;
 import com.refinedmods.refinedstorage.api.storage.Actor;
 import com.refinedmods.refinedstorage.api.storage.Storage;
 import com.refinedmods.refinedstorage.api.storage.StorageImpl;
@@ -18,11 +19,13 @@ class ExternalPatternSinkProviderImpl implements ExternalPatternSinkProvider {
     private final Map<PatternLayout, ExternalPatternSink> sinks = new HashMap<>();
 
     ExternalPatternSinkImpl put(final Pattern pattern) {
-        return put(pattern, new ExternalPatternSinkImpl(new StorageImpl(), pattern, null));
+        return put(pattern, new ExternalPatternSinkImpl(new StorageImpl(MutableResourceListImpl.orderPreserving()),
+            pattern, null));
     }
 
     void put(final Pattern pattern, final ExternalPatternSink.Result fixedResult) {
-        put(pattern, new ExternalPatternSinkImpl(new StorageImpl(), pattern, fixedResult));
+        put(pattern, new ExternalPatternSinkImpl(new StorageImpl(MutableResourceListImpl.orderPreserving()), pattern,
+            fixedResult));
     }
 
     <T extends ExternalPatternSink> T put(final Pattern pattern, final T sink) {

--- a/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/task/TaskImplTest.java
+++ b/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/task/TaskImplTest.java
@@ -811,6 +811,49 @@ class TaskImplTest {
     }
 
     @Test
+    void shouldRespectPatternInputOrderForExternalPattern() {
+        // Arrange
+        final RootStorage storage = storage(
+            new ResourceAmount(COBBLESTONE, 64),
+            new ResourceAmount(IRON_INGOT, 64),
+            new ResourceAmount(STICKS, 64)
+        );
+        final Pattern pattern = pattern(PatternType.EXTERNAL)
+            .ingredient(COBBLESTONE, 2)
+            .ingredient(IRON_INGOT, 3)
+            .ingredient(STICKS, 1)
+            .output(STONE, 1)
+            .build();
+        final PatternRepository patterns = patterns(pattern);
+        final ExternalPatternSinkProviderImpl sinkProvider = new ExternalPatternSinkProviderImpl();
+        final ExternalPatternSinkProviderImpl.ExternalPatternSinkImpl sink = sinkProvider.put(pattern);
+        final Task task = getRunningTask(storage, patterns, sinkProvider, STONE, 1);
+
+        assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(
+            new ResourceAmount(COBBLESTONE, 62),
+            new ResourceAmount(IRON_INGOT, 61),
+            new ResourceAmount(STICKS, 63)
+        );
+        assertThat(copyInternalStorage(task))
+            .usingRecursiveFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new ResourceAmount(COBBLESTONE, 2),
+                new ResourceAmount(IRON_INGOT, 3),
+                new ResourceAmount(STICKS, 1)
+            );
+
+        // Act & assert
+        assertThat(task.step(storage, sinkProvider, StepBehavior.DEFAULT, TaskListener.EMPTY)).isTrue();
+        assertThat(task.getState()).isEqualTo(TaskState.RUNNING);
+        assertThat(copyInternalStorage(task)).isEmpty();
+        assertThat(sink.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+            new ResourceAmount(COBBLESTONE, 2),
+            new ResourceAmount(IRON_INGOT, 3),
+            new ResourceAmount(STICKS, 1)
+        );
+    }
+
+    @Test
     void shouldStepAccordingToCustomStepBehavior() {
         // Arrange
         final RootStorage storage = storage(


### PR DESCRIPTION
All changes are necessary.
As soon as I remove each change,
the test fails.

Fixes #952
Fixes #1012