### PR TITLE
perf: resolve item tooltip attribute lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+-   Reduce lag spikes when opening a Grid with many item types. 
+
 ### Added
 
 -   Warning to the resource type side button when the Grid is filtering by resource type and there are no resources for that type to display.

--- a/refinedstorage-common-api/src/main/java/com/refinedmods/refinedstorage/common/api/grid/view/AbstractGridResource.java
+++ b/refinedstorage-common-api/src/main/java/com/refinedmods/refinedstorage/common/api/grid/view/AbstractGridResource.java
@@ -17,11 +17,20 @@ import org.apiguardian.api.API;
 public abstract class AbstractGridResource<T extends PlatformResourceKey> implements GridResource {
     protected final T resource;
     private final String name;
-    private final Map<GridResourceAttributeKey, Set<String>> attributes;
+    private final Function<GridResourceAttributeKey, Set<String>> attributes;
 
+    // TODO: merge constructors for >=1.22
     protected AbstractGridResource(final T resource,
                                    final String name,
                                    final Map<GridResourceAttributeKey, Set<String>> attributes) {
+        this.resource = resource;
+        this.name = name;
+        this.attributes = key -> attributes.getOrDefault(key, Collections.emptySet());
+    }
+
+    protected AbstractGridResource(final T resource,
+                                   final String name,
+                                   final Function<GridResourceAttributeKey, Set<String>> attributes) {
         this.resource = resource;
         this.name = name;
         this.attributes = attributes;
@@ -45,7 +54,7 @@ public abstract class AbstractGridResource<T extends PlatformResourceKey> implem
 
     @Override
     public Set<String> getAttribute(final GridResourceAttributeKey key) {
-        return attributes.getOrDefault(key, Collections.emptySet());
+        return attributes.apply(key);
     }
 
     @Override

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/AbstractFluidGridResourceRepositoryMapper.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/AbstractFluidGridResourceRepositoryMapper.java
@@ -4,12 +4,16 @@ import com.refinedmods.refinedstorage.api.resource.ResourceKey;
 import com.refinedmods.refinedstorage.api.resource.repository.ResourceRepositoryMapper;
 import com.refinedmods.refinedstorage.common.api.grid.GridResourceAttributeKeys;
 import com.refinedmods.refinedstorage.common.api.grid.view.GridResource;
+import com.refinedmods.refinedstorage.common.api.grid.view.GridResourceAttributeKey;
 import com.refinedmods.refinedstorage.common.support.resource.FluidResource;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Suppliers;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.material.Fluid;
@@ -21,17 +25,16 @@ public abstract class AbstractFluidGridResourceRepositoryMapper implements Resou
         final String name = getName(fluidResource);
         final String modId = getModId(fluidResource);
         final String modName = getModName(modId);
-        final Set<String> tags = getTags(fluidResource.fluid());
-        final String tooltip = getTooltip(fluidResource);
+        final Map<GridResourceAttributeKey, Supplier<Set<String>>> attributes = Map.of(
+            GridResourceAttributeKeys.MOD_ID, Suppliers.ofInstance(Set.of(modId)),
+            GridResourceAttributeKeys.MOD_NAME, Suppliers.ofInstance(Set.of(modName)),
+            GridResourceAttributeKeys.TAGS, Suppliers.ofInstance(getTags(fluidResource.fluid())),
+            GridResourceAttributeKeys.TOOLTIP, Suppliers.ofInstance(Set.of(getTooltip(fluidResource)))
+        );
         return new FluidGridResource(
             fluidResource,
             name,
-            Map.of(
-                GridResourceAttributeKeys.MOD_ID, Set.of(modId),
-                GridResourceAttributeKeys.MOD_NAME, Set.of(modName),
-                GridResourceAttributeKeys.TAGS, tags,
-                GridResourceAttributeKeys.TOOLTIP, Set.of(tooltip)
-            )
+            k -> attributes.getOrDefault(k, Collections::emptySet).get()
         );
     }
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/AbstractItemGridResourceRepositoryMapper.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/AbstractItemGridResourceRepositoryMapper.java
@@ -4,13 +4,17 @@ import com.refinedmods.refinedstorage.api.resource.ResourceKey;
 import com.refinedmods.refinedstorage.api.resource.repository.ResourceRepositoryMapper;
 import com.refinedmods.refinedstorage.common.api.grid.GridResourceAttributeKeys;
 import com.refinedmods.refinedstorage.common.api.grid.view.GridResource;
+import com.refinedmods.refinedstorage.common.api.grid.view.GridResourceAttributeKey;
 import com.refinedmods.refinedstorage.common.support.resource.ItemResource;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
@@ -31,18 +35,17 @@ public abstract class AbstractItemGridResourceRepositoryMapper implements Resour
         final String name = item.getName(itemStack).getString();
         final String modId = getModId(itemStack);
         final String modName = getModName(modId).orElse("");
-        final Set<String> tags = getTags(item);
-        final String tooltip = getTooltip(itemStack);
+        final Map<GridResourceAttributeKey, Supplier<Set<String>>> attributes = Map.of(
+            GridResourceAttributeKeys.MOD_ID, Suppliers.ofInstance(Set.of(modId)),
+            GridResourceAttributeKeys.MOD_NAME, Suppliers.ofInstance(Set.of(modName)),
+            GridResourceAttributeKeys.TAGS, Suppliers.memoize(() -> getTags(item)),
+            GridResourceAttributeKeys.TOOLTIP, Suppliers.memoize(() -> Set.of(getTooltip(itemStack)))
+        );
         return new ItemGridResource(
             itemResource,
             itemStack,
             name,
-            Map.of(
-                GridResourceAttributeKeys.MOD_ID, Set.of(modId),
-                GridResourceAttributeKeys.MOD_NAME, Set.of(modName),
-                GridResourceAttributeKeys.TAGS, tags,
-                GridResourceAttributeKeys.TOOLTIP, Set.of(tooltip)
-            )
+            k -> attributes.getOrDefault(k, Collections::emptySet).get()
         );
     }
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/FluidGridResource.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/FluidGridResource.java
@@ -19,9 +19,9 @@ import com.refinedmods.refinedstorage.common.support.resource.ResourceTypes;
 import com.refinedmods.refinedstorage.common.support.tooltip.MouseClientTooltipComponent;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import net.minecraft.client.gui.GuiGraphics;
@@ -40,7 +40,7 @@ public class FluidGridResource extends AbstractGridResource<FluidResource> {
 
     public FluidGridResource(final FluidResource resource,
                              final String name,
-                             final Map<GridResourceAttributeKey, Set<String>> attributes) {
+                             final Function<GridResourceAttributeKey, Set<String>> attributes) {
         super(resource, name, attributes);
         this.id = BuiltInRegistries.FLUID.getId(resource.fluid());
         this.rendering = RefinedStorageClientApi.INSTANCE.getResourceRendering(FluidResource.class);

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/ItemGridResource.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/ItemGridResource.java
@@ -16,9 +16,9 @@ import com.refinedmods.refinedstorage.common.support.tooltip.MouseClientTooltipC
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 
 import net.minecraft.client.Minecraft;
@@ -46,7 +46,7 @@ public class ItemGridResource extends AbstractGridResource<ItemResource> {
     public ItemGridResource(final ItemResource resource,
                             final ItemStack itemStack,
                             final String name,
-                            final Map<GridResourceAttributeKey, Set<String>> attributes) {
+                            final Function<GridResourceAttributeKey, Set<String>> attributes) {
         super(resource, name, attributes);
         this.id = Item.getId(resource.item());
         this.itemStack = itemStack;


### PR DESCRIPTION
This PR at least partially addresses slow Grid opening.
I noticed that a lot of time is spent in `AbstractItemGridResourceRepositoryMapper#getTooltip(ItemStack)`. However, this information is only ever used when searching. It shouldn't slow down opening the grid.

By only resolving the tooltip lazily, the expensive part only happens when it is actually needed.

I backported this change to beta.3 as this is what's currently running on my ATM10 server. There, `ViewList#createSorted(...)` previously took 1-2s each time when opening. With this change, it's down to 50-100ms. I measured using a custom JFR event and repeatedly open/close the grid to ensure the JIT kicks in first.

Please let me know what you think.