### PR TITLE
fix: not differentiating between outputs and byproducts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
--  Warning to the resource type side button when the Grid is filtering by resource type and there are no resources for that type to display.
+-   Warning to the resource type side button when the Grid is filtering by resource type and there are no resources for that type to display.
+
+### Fixed
+
+-   Autocrafting not properly differentiating between outputs and byproducts and calculating the wrong task when requesting a byproduct of another pattern.
 
 ## [2.0.0-beta.10] - 2025-08-19
 

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/PatternBuilder.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/PatternBuilder.java
@@ -14,6 +14,7 @@ public class PatternBuilder {
     private final PatternType type;
     private final List<Ingredient> ingredients = new ArrayList<>();
     private final List<ResourceAmount> outputs = new ArrayList<>();
+    private final List<ResourceAmount> byproducts = new ArrayList<>();
 
     private PatternBuilder(final PatternType type) {
         this.type = type;
@@ -41,8 +42,13 @@ public class PatternBuilder {
         return this;
     }
 
+    public PatternBuilder byproduct(final ResourceKey byproduct, final long amount) {
+        byproducts.add(new ResourceAmount(byproduct, amount));
+        return this;
+    }
+
     public PatternLayout buildLayout() {
-        return new PatternLayout(ingredients, outputs, type);
+        return new PatternLayout(ingredients, outputs, byproducts, type);
     }
 
     public Pattern build() {

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/PatternLayout.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/PatternLayout.java
@@ -12,18 +12,38 @@ import org.apiguardian.api.API;
  *
  * @param ingredients the ingredients
  * @param outputs     the outputs
+ * @param byproducts  the byproducts
  * @param type        the type
  */
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.4.12")
-public record PatternLayout(List<Ingredient> ingredients, List<ResourceAmount> outputs, PatternType type) {
+public record PatternLayout(List<Ingredient> ingredients,
+                            List<ResourceAmount> outputs,
+                            List<ResourceAmount> byproducts,
+                            PatternType type) {
     public PatternLayout(final List<Ingredient> ingredients,
                          final List<ResourceAmount> outputs,
+                         final List<ResourceAmount> byproducts,
                          final PatternType type) {
         CoreValidations.validateNotEmpty(ingredients, "Ingredients cannot be empty");
         CoreValidations.validateNotEmpty(outputs, "Outputs cannot be empty");
+        CoreValidations.validateNotNull(byproducts, "Byproducts cannot be null");
         CoreValidations.validateNotNull(type, "Type cannot be null");
+        if (type == PatternType.EXTERNAL && !byproducts.isEmpty()) {
+            throw new IllegalArgumentException("External patterns cannot have byproducts");
+        }
         this.ingredients = List.copyOf(ingredients);
         this.outputs = List.copyOf(outputs);
+        this.byproducts = List.copyOf(byproducts);
         this.type = type;
+    }
+
+    public static PatternLayout external(final List<Ingredient> ingredients, final List<ResourceAmount> outputs) {
+        return new PatternLayout(ingredients, outputs, List.of(), PatternType.EXTERNAL);
+    }
+
+    public static PatternLayout internal(final List<Ingredient> ingredients,
+                                         final List<ResourceAmount> outputs,
+                                         final List<ResourceAmount> byproducts) {
+        return new PatternLayout(ingredients, outputs, byproducts, PatternType.INTERNAL);
     }
 }

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/InternalTaskPattern.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/InternalTaskPattern.java
@@ -49,6 +49,7 @@ class InternalTaskPattern extends AbstractTaskPattern {
         final ResourceList iterationInputs = calculateIterationInputs(Action.EXECUTE);
         extractAll(iterationInputs, internalStorage, Action.EXECUTE);
         pattern.layout().outputs().forEach(output -> returnOutput(internalStorage, rootStorage, output));
+        pattern.layout().byproducts().forEach(byproduct -> returnOutput(internalStorage, rootStorage, byproduct));
         return useIteration();
     }
 

--- a/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/PatternRepositoryImplTest.java
+++ b/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/PatternRepositoryImplTest.java
@@ -8,16 +8,25 @@ import static com.refinedmods.refinedstorage.api.autocrafting.PatternBuilder.pat
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.A;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.B;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.C;
+import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.X;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PatternRepositoryImplTest {
-    private static final Pattern PATTERN_A = pattern().ingredient(C, 1).output(A, 1).build();
-    private static final Pattern PATTERN_AB = pattern().ingredient(C, 1)
+    private static final Pattern PATTERN_A = pattern()
+        .ingredient(C, 1)
+        .output(A, 1)
+        .byproduct(X, 1)
+        .build();
+    private static final Pattern PATTERN_AB = pattern()
+        .ingredient(C, 1)
         .output(A, 1)
         .output(B, 1)
         .build();
-    private static final Pattern PATTERN_B = pattern().ingredient(C, 1).output(B, 1).build();
+    private static final Pattern PATTERN_B = pattern()
+        .ingredient(C, 1)
+        .output(B, 1)
+        .build();
 
     private PatternRepositoryImpl sut;
 
@@ -46,6 +55,7 @@ class PatternRepositoryImplTest {
         assertThat(sut.getByOutput(A)).usingRecursiveFieldByFieldElementComparator().containsExactly(
             PATTERN_A
         );
+        assertThat(sut.getByOutput(X)).isEmpty();
     }
 
     @Test

--- a/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/PatternTest.java
+++ b/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/PatternTest.java
@@ -8,10 +8,13 @@ import java.util.UUID;
 
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.A;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.B;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.C;
+import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.COBBLESTONE;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.OAK_LOG;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.OAK_PLANKS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,7 +22,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class PatternTest {
     @Test
-    void testPattern() {
+    void shouldCreateInternalPattern() {
         // Act
         final Pattern sut = new Pattern(
             UUID.randomUUID(),
@@ -31,6 +34,9 @@ class PatternTest {
                 List.of(
                     new ResourceAmount(OAK_LOG, 3),
                     new ResourceAmount(OAK_PLANKS, 4)
+                ),
+                List.of(
+                    new ResourceAmount(COBBLESTONE, 1)
                 ),
                 PatternType.INTERNAL
             )
@@ -48,11 +54,14 @@ class PatternTest {
             new ResourceAmount(OAK_LOG, 3),
             new ResourceAmount(OAK_PLANKS, 4)
         );
+        assertThat(sut.layout().byproducts()).usingRecursiveFieldByFieldElementComparator()
+            .containsExactly(new ResourceAmount(COBBLESTONE, 1));
         assertThat(sut.layout().type()).isEqualTo(PatternType.INTERNAL);
     }
 
-    @Test
-    void shouldNotCreatePatternWithoutIngredients() {
+    @ParameterizedTest
+    @EnumSource(PatternType.class)
+    void shouldNotCreatePatternWithoutIngredients(final PatternType type) {
         // Act
         final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
             UUID.randomUUID(),
@@ -62,16 +71,20 @@ class PatternTest {
                     new ResourceAmount(OAK_LOG, 3),
                     new ResourceAmount(OAK_PLANKS, 4)
                 ),
-                PatternType.INTERNAL
+                List.of(),
+                type
             )
         );
 
         // Assert
-        assertThatThrownBy(action).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(action)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Ingredients cannot be empty");
     }
 
-    @Test
-    void shouldNotCreatePatternWithoutOutputs() {
+    @ParameterizedTest
+    @EnumSource(PatternType.class)
+    void shouldNotCreatePatternWithoutOutputs(final PatternType type) {
         // Act
         final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
             UUID.randomUUID(),
@@ -81,64 +94,75 @@ class PatternTest {
                     new Ingredient(2, List.of(C))
                 ),
                 List.of(),
-                PatternType.INTERNAL
+                List.of(),
+                type
             )
         );
 
         // Assert
-        assertThatThrownBy(action).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(action)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Outputs cannot be empty");
     }
 
     @Test
-    void shouldCopyIngredientsAndOutputs() {
+    void shouldCopyIngredientsAndOutputsAndByproducts() {
         // Arrange
         final List<Ingredient> ingredients = new ArrayList<>();
         ingredients.add(new Ingredient(1, List.of(A, B)));
         final List<ResourceAmount> outputs = new ArrayList<>();
         outputs.add(new ResourceAmount(OAK_LOG, 3));
+        final List<ResourceAmount> byproducts = new ArrayList<>();
+        byproducts.add(new ResourceAmount(COBBLESTONE, 1));
         final Pattern sut = new Pattern(
             UUID.randomUUID(),
-            new PatternLayout(ingredients, outputs, PatternType.INTERNAL)
+            new PatternLayout(ingredients, outputs, byproducts, PatternType.INTERNAL)
         );
 
         // Act
         ingredients.add(new Ingredient(2, List.of(C)));
         outputs.add(new ResourceAmount(OAK_PLANKS, 4));
+        byproducts.add(new ResourceAmount(OAK_LOG, 2));
 
         // Assert
         assertThat(sut.layout().ingredients()).hasSize(1);
         assertThat(sut.layout().outputs()).hasSize(1);
+        assertThat(sut.layout().byproducts()).hasSize(1);
     }
 
     @Test
-    void shouldNotBeAbleToModifyIngredientsAndOutputs() {
+    void shouldNotBeAbleToModifyIngredientsAndOutputsAndByproducts() {
         // Arrange
         final Pattern sut = new Pattern(
             UUID.randomUUID(),
             new PatternLayout(
                 List.of(new Ingredient(1, List.of(A))),
                 List.of(new ResourceAmount(OAK_LOG, 3)),
+                List.of(new ResourceAmount(OAK_PLANKS, 4)),
                 PatternType.INTERNAL
             )
         );
         final List<Ingredient> ingredients = sut.layout().ingredients();
         final List<ResourceAmount> outputs = sut.layout().outputs();
+        final List<ResourceAmount> byproducts = sut.layout().byproducts();
 
         final Ingredient newIngredient = new Ingredient(2, List.of(B));
         final ResourceAmount newOutput = new ResourceAmount(OAK_PLANKS, 4);
+        final ResourceAmount newByproduct = new ResourceAmount(OAK_LOG, 2);
 
         // Act
         final ThrowableAssert.ThrowingCallable action = () -> ingredients.add(newIngredient);
         final ThrowableAssert.ThrowingCallable action2 = () -> outputs.add(newOutput);
+        final ThrowableAssert.ThrowingCallable action3 = () -> byproducts.add(newByproduct);
 
         // Assert
         assertThatThrownBy(action).isInstanceOf(UnsupportedOperationException.class);
         assertThatThrownBy(action2).isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(action3).isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
-    void shouldNotCreatePatternWithoutPatternType() {
+    void shouldNotCreateExternalPatternWithByproducts() {
         // Act
         final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
             UUID.randomUUID(),
@@ -151,7 +175,80 @@ class PatternTest {
                     new ResourceAmount(OAK_LOG, 3),
                     new ResourceAmount(OAK_PLANKS, 4)
                 ),
+                List.of(
+                    new ResourceAmount(COBBLESTONE, 1)
+                ),
+                PatternType.EXTERNAL
+            )
+        );
+
+        // Assert
+        assertThatThrownBy(action)
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("External patterns cannot have byproducts");
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void shouldNotCreatePatternWithNullType() {
+        // Act
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
+            UUID.randomUUID(),
+            new PatternLayout(
+                List.of(
+                    new Ingredient(1, List.of(A, B)),
+                    new Ingredient(2, List.of(C))
+                ),
+                List.of(
+                    new ResourceAmount(OAK_LOG, 3),
+                    new ResourceAmount(OAK_PLANKS, 4)
+                ),
+                List.of(),
                 null
+            )
+        );
+
+        // Assert
+        assertThatThrownBy(action).isInstanceOf(NullPointerException.class);
+    }
+
+    @ParameterizedTest
+    @EnumSource(PatternType.class)
+    @SuppressWarnings("ConstantConditions")
+    void shouldNotCreatePatternWithNullIngredients(final PatternType type) {
+        // Act
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
+            UUID.randomUUID(),
+            new PatternLayout(
+                null,
+                List.of(
+                    new ResourceAmount(OAK_LOG, 3),
+                    new ResourceAmount(OAK_PLANKS, 4)
+                ),
+                List.of(),
+                type
+            )
+        );
+
+        // Assert
+        assertThatThrownBy(action).isInstanceOf(NullPointerException.class);
+    }
+
+    @ParameterizedTest
+    @EnumSource(PatternType.class)
+    @SuppressWarnings("ConstantConditions")
+    void shouldNotCreatePatternWithNullOutputs(final PatternType type) {
+        // Act
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
+            UUID.randomUUID(),
+            new PatternLayout(
+                List.of(
+                    new Ingredient(1, List.of(A, B)),
+                    new Ingredient(2, List.of(C))
+                ),
+                null,
+                List.of(),
+                type
             )
         );
 
@@ -161,7 +258,31 @@ class PatternTest {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    void shouldNotCreateWithoutId() {
+    void shouldNotCreatePatternWithNullByproducts() {
+        // Act
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
+            UUID.randomUUID(),
+            new PatternLayout(
+                List.of(
+                    new Ingredient(1, List.of(A, B)),
+                    new Ingredient(2, List.of(C))
+                ),
+                List.of(
+                    new ResourceAmount(OAK_LOG, 3),
+                    new ResourceAmount(OAK_PLANKS, 4)
+                ),
+                null,
+                PatternType.INTERNAL
+            )
+        );
+
+        // Assert
+        assertThatThrownBy(action).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @SuppressWarnings("ConstantConditions")
+    void shouldNotCreateWithNullId() {
         // Act
         final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
             null,
@@ -174,6 +295,7 @@ class PatternTest {
                     new ResourceAmount(OAK_LOG, 3),
                     new ResourceAmount(OAK_PLANKS, 4)
                 ),
+                List.of(),
                 PatternType.INTERNAL
             )
         );

--- a/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/ResourceFixtures.java
+++ b/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/ResourceFixtures.java
@@ -6,6 +6,8 @@ public enum ResourceFixtures implements ResourceKey {
     A,
     B,
     C,
+    X,
+    Y,
     SPRUCE_LOG,
     OAK_LOG,
     OAK_PLANKS,

--- a/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/task/TaskImplTest.java
+++ b/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/task/TaskImplTest.java
@@ -35,6 +35,8 @@ import static com.refinedmods.refinedstorage.api.autocrafting.PatternFixtures.SP
 import static com.refinedmods.refinedstorage.api.autocrafting.PatternFixtures.STICKS_PATTERN;
 import static com.refinedmods.refinedstorage.api.autocrafting.PatternFixtures.STONE_PATTERN;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.A;
+import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.B;
+import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.C;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.COBBLESTONE;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.CRAFTING_TABLE;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.IRON_INGOT;
@@ -49,6 +51,8 @@ import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.S
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.STICKS;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.STONE;
 import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.STONE_BRICKS;
+import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.X;
+import static com.refinedmods.refinedstorage.api.autocrafting.ResourceFixtures.Y;
 import static com.refinedmods.refinedstorage.api.autocrafting.task.ExternalPatternSinkProviderImpl.sinkKey;
 import static com.refinedmods.refinedstorage.api.autocrafting.task.TaskPlanCraftingCalculatorListener.calculatePlan;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -286,6 +290,92 @@ class TaskImplTest {
             new ResourceAmount(SIGN, 10),
             new ResourceAmount(CRAFTING_TABLE, 3)
         );
+    }
+
+    @Test
+    void shouldCompleteTaskWithByproductsInInternalPattern() {
+        // Arrange
+        final RootStorage storage = storage(
+            new ResourceAmount(A, 100)
+        );
+        final Pattern patternThatMakesB = pattern()
+            .ingredient(A, 1)
+            .output(B, 1)
+            .byproduct(X, 1)
+            .build();
+        final Pattern patternThatMakesC = pattern()
+            .ingredient(B, 1)
+            .output(C, 1)
+            .byproduct(Y, 1)
+            .build();
+        final PatternRepository patterns = patterns(patternThatMakesB, patternThatMakesC);
+        final Task task = getRunningTask(storage, patterns, EMPTY_SINK_PROVIDER, C, 3);
+
+        // Act & assert
+        task.step(storage, EMPTY_SINK_PROVIDER, StepBehavior.DEFAULT, TaskListener.EMPTY);
+        assertThat(task.getState()).isEqualTo(TaskState.RUNNING);
+        assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+            new ResourceAmount(A, 97)
+        );
+        assertThat(copyInternalStorage(task))
+            .usingRecursiveFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new ResourceAmount(A, 2),
+                new ResourceAmount(B, 1),
+                new ResourceAmount(X, 1)
+            );
+
+        task.step(storage, EMPTY_SINK_PROVIDER, StepBehavior.DEFAULT, TaskListener.EMPTY);
+        assertThat(task.getState()).isEqualTo(TaskState.RUNNING);
+        assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(
+            new ResourceAmount(A, 97),
+            new ResourceAmount(C, 1),
+            new ResourceAmount(Y, 1)
+        );
+        assertThat(copyInternalStorage(task))
+            .usingRecursiveFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new ResourceAmount(A, 1),
+                new ResourceAmount(B, 1),
+                new ResourceAmount(X, 2)
+            );
+
+        task.step(storage, EMPTY_SINK_PROVIDER, StepBehavior.DEFAULT, TaskListener.EMPTY);
+        assertThat(task.getState()).isEqualTo(TaskState.RUNNING);
+        assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(
+            new ResourceAmount(A, 97),
+            new ResourceAmount(C, 2),
+            new ResourceAmount(Y, 2)
+        );
+        assertThat(copyInternalStorage(task))
+            .usingRecursiveFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new ResourceAmount(B, 1),
+                new ResourceAmount(X, 3)
+            );
+
+        task.step(storage, EMPTY_SINK_PROVIDER, StepBehavior.DEFAULT, TaskListener.EMPTY);
+        assertThat(task.getState()).isEqualTo(TaskState.RETURNING_INTERNAL_STORAGE);
+        assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(
+            new ResourceAmount(A, 97),
+            new ResourceAmount(C, 3),
+            new ResourceAmount(Y, 3)
+        );
+        assertThat(copyInternalStorage(task))
+            .usingRecursiveFieldByFieldElementComparator()
+            .containsExactlyInAnyOrder(
+                new ResourceAmount(X, 3)
+            );
+
+        task.step(storage, EMPTY_SINK_PROVIDER, StepBehavior.DEFAULT, TaskListener.EMPTY);
+        assertThat(task.getState()).isEqualTo(TaskState.COMPLETED);
+        assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(
+            new ResourceAmount(A, 97),
+            new ResourceAmount(C, 3),
+            new ResourceAmount(Y, 3),
+            new ResourceAmount(X, 3)
+        );
+        assertThat(copyInternalStorage(task)).isEmpty();
     }
 
     @Test

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/PatternResolver.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/PatternResolver.java
@@ -3,7 +3,6 @@ package com.refinedmods.refinedstorage.common.autocrafting;
 import com.refinedmods.refinedstorage.api.autocrafting.Ingredient;
 import com.refinedmods.refinedstorage.api.autocrafting.Pattern;
 import com.refinedmods.refinedstorage.api.autocrafting.PatternLayout;
-import com.refinedmods.refinedstorage.api.autocrafting.PatternType;
 import com.refinedmods.refinedstorage.api.resource.ResourceAmount;
 import com.refinedmods.refinedstorage.api.resource.ResourceKey;
 import com.refinedmods.refinedstorage.common.content.DataComponents;
@@ -16,7 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.CraftingInput;
@@ -217,13 +215,13 @@ public class PatternResolver {
                                 final List<List<ResourceKey>> inputs,
                                 final ResourceAmount output,
                                 final List<ResourceAmount> byproducts) {
-            this(inputs, output, new Pattern(id, new PatternLayout(
+            this(inputs, output, new Pattern(id, PatternLayout.internal(
                 inputs.stream()
                     .filter(i -> !i.isEmpty())
                     .map(i -> new Ingredient(1, i))
                     .toList(),
-                Stream.concat(Stream.of(output), byproducts.stream()).toList(),
-                PatternType.INTERNAL
+                List.of(output),
+                byproducts
             )));
         }
     }
@@ -232,7 +230,7 @@ public class PatternResolver {
         ResolvedProcessingPattern(final UUID id,
                                   final List<Ingredient> ingredients,
                                   final List<ResourceAmount> outputs) {
-            this(new Pattern(id, new PatternLayout(ingredients, outputs, PatternType.EXTERNAL)));
+            this(new Pattern(id, PatternLayout.external(ingredients, outputs)));
         }
     }
 
@@ -240,10 +238,10 @@ public class PatternResolver {
                                              ItemResource output,
                                              Pattern pattern) {
         ResolvedStonecutterPattern(final UUID id, final ItemResource input, final ItemResource output) {
-            this(input, output, new Pattern(id, new PatternLayout(
+            this(input, output, new Pattern(id, PatternLayout.internal(
                 List.of(new Ingredient(1, List.of(input))),
                 List.of(new ResourceAmount(output, 1)),
-                PatternType.INTERNAL
+                List.of()
             )));
         }
     }
@@ -258,10 +256,10 @@ public class PatternResolver {
                                      final ItemResource base,
                                      final ItemResource addition,
                                      final ItemResource output) {
-            this(template, base, addition, output, new Pattern(id, new PatternLayout(
+            this(template, base, addition, output, new Pattern(id, PatternLayout.internal(
                 List.of(single(template), single(base), single(addition)),
                 List.of(new ResourceAmount(output, 1)),
-                PatternType.INTERNAL
+                List.of()
             )));
         }
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/autocrafter/TaskSnapshotPersistence.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/autocrafter/TaskSnapshotPersistence.java
@@ -50,6 +50,7 @@ final class TaskSnapshotPersistence {
     private static final String PATTERN_TYPE = "type";
     private static final String INGREDIENTS = "ingredients";
     private static final String OUTPUTS = "outputs";
+    private static final String BYPRODUCTS = "byproducts";
     private static final String ID = "id";
     private static final String EXTERNAL_PATTERN = "externalPattern";
     private static final String INTERNAL_PATTERN = "internalPattern";
@@ -115,6 +116,12 @@ final class TaskSnapshotPersistence {
             outputs.add(ResourceCodecs.AMOUNT_CODEC.encode(output, NbtOps.INSTANCE, new CompoundTag()).getOrThrow());
         }
         tag.put(OUTPUTS, outputs);
+        final ListTag byproducts = new ListTag();
+        for (final ResourceAmount byproduct : pattern.layout().byproducts()) {
+            byproducts.add(ResourceCodecs.AMOUNT_CODEC.encode(byproduct, NbtOps.INSTANCE,
+                new CompoundTag()).getOrThrow());
+        }
+        tag.put(BYPRODUCTS, byproducts);
         tag.putString(PATTERN_TYPE, pattern.layout().type().name());
         return tag;
     }
@@ -288,8 +295,12 @@ final class TaskSnapshotPersistence {
         for (final Tag outputTag : tag.getList(OUTPUTS, Tag.TAG_COMPOUND)) {
             outputs.add(ResourceCodecs.AMOUNT_CODEC.parse(NbtOps.INSTANCE, outputTag).result().orElseThrow());
         }
+        final List<ResourceAmount> byproducts = new ArrayList<>();
+        for (final Tag byproductTag : tag.getList(BYPRODUCTS, Tag.TAG_COMPOUND)) {
+            byproducts.add(ResourceCodecs.AMOUNT_CODEC.parse(NbtOps.INSTANCE, byproductTag).result().orElseThrow());
+        }
         final PatternType type = PatternType.valueOf(tag.getString(PATTERN_TYPE));
-        return new Pattern(id, new PatternLayout(ingredients, outputs, type));
+        return new Pattern(id, new PatternLayout(ingredients, outputs, byproducts, type));
     }
 
     private static Ingredient decodeIngredient(final CompoundTag tag) {


### PR DESCRIPTION
Side effect without this bugfix:
calculating the wrong task when requesting
 a byproduct of another pattern.

 For example:
 * a pattern for a bucket
 * a recipe that has an empty bucket as byproduct

 When requesting a bucket,
 it would calculate for the recipe
 with the bucket as byproduct
 instead since it is technically
 an output of that pattern.

 Fixes #1009
 Fixes #1025