### PR TITLE
perf: optimize autocrafting calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 -   Rare crash when starting an autocrafting task.
+-   Optimize autocrafting calculation performance.
 
 ## [2.0.0-beta.11] - 2025-08-25
 

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/CraftingState.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/CraftingState.java
@@ -8,17 +8,13 @@ import com.refinedmods.refinedstorage.api.resource.list.MutableResourceList;
 import com.refinedmods.refinedstorage.api.resource.list.MutableResourceListImpl;
 import com.refinedmods.refinedstorage.api.storage.root.RootStorage;
 
-import java.util.Comparator;
-
 class CraftingState {
     private final MutableResourceList storage;
     private final MutableResourceList internalStorage;
-    private final Comparator<ResourceKey> sorter;
 
     private CraftingState(final MutableResourceList storage, final MutableResourceList internalStorage) {
         this.storage = storage;
         this.internalStorage = internalStorage;
-        this.sorter = createSorter(storage).thenComparing(createSorter(internalStorage));
     }
 
     void extractFromInternalStorage(final ResourceKey resource, final long amount) {
@@ -51,29 +47,28 @@ class CraftingState {
         return new CraftingState(LazyCopyMutableResourceList.create(storage), MutableResourceListImpl.create());
     }
 
-    Comparator<ResourceKey> getSorter() {
-        return sorter;
-    }
-
-    private static Comparator<ResourceKey> createSorter(final MutableResourceList list) {
-        return (a, b) -> {
-            final long ar = list.get(a);
-            final long br = list.get(b);
-            return (int) br - (int) ar;
-        };
-    }
-
     ResourceState getResource(final ResourceKey resource) {
         return new ResourceState(resource, storage.get(resource), internalStorage.get(resource));
     }
 
-    record ResourceState(ResourceKey resource, long inStorage, long inInternalStorage) {
+    record ResourceState(ResourceKey resource, long inStorage, long inInternalStorage)
+        implements Comparable<ResourceState> {
         boolean isInStorage() {
             return inStorage > 0;
         }
 
         boolean isInInternalStorage() {
             return inInternalStorage > 0;
+        }
+
+        @Override
+        public int compareTo(final ResourceState o) {
+            // o first, we want greater values to come first
+            final int storage = Long.compare(o.inStorage, inStorage);
+            if (storage == 0) {
+                return Long.compare(o.inInternalStorage, inInternalStorage);
+            }
+            return storage;
         }
     }
 }

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/CraftingState.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/CraftingState.java
@@ -3,6 +3,7 @@ package com.refinedmods.refinedstorage.api.autocrafting.calculation;
 import com.refinedmods.refinedstorage.api.autocrafting.Pattern;
 import com.refinedmods.refinedstorage.api.resource.ResourceAmount;
 import com.refinedmods.refinedstorage.api.resource.ResourceKey;
+import com.refinedmods.refinedstorage.api.resource.list.LazyCopyMutableResourceList;
 import com.refinedmods.refinedstorage.api.resource.list.MutableResourceList;
 import com.refinedmods.refinedstorage.api.resource.list.MutableResourceListImpl;
 import com.refinedmods.refinedstorage.api.storage.root.RootStorage;
@@ -47,7 +48,7 @@ class CraftingState {
     static CraftingState of(final RootStorage rootStorage) {
         final MutableResourceListImpl storage = MutableResourceListImpl.create();
         rootStorage.getAll().forEach(storage::add);
-        return new CraftingState(storage, MutableResourceListImpl.create());
+        return new CraftingState(LazyCopyMutableResourceList.create(storage), MutableResourceListImpl.create());
     }
 
     Comparator<ResourceKey> getSorter() {

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/CraftingTree.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/CraftingTree.java
@@ -87,7 +87,7 @@ class CraftingTree<T> {
     private CalculationResult calculateIngredient(final int ingredientIndex, final IngredientState ingredientState,
                                                   final CancellationToken cancellationToken)
         throws CancellationException {
-        CraftingState.ResourceState resourceState = craftingState.getResource(ingredientState.get());
+        CraftingState.ResourceState resourceState = ingredientState.get();
         long remaining = ingredientState.amount() * amount.iterations();
         if (remaining < 0) {
             throw new NumberOverflowDuringCalculationException();
@@ -136,7 +136,6 @@ class CraftingTree<T> {
             return calculateChild(ingredientState, remaining, childPatterns, resourceState, cancellationToken);
         }
         return ingredientState.cycle()
-            .map(craftingState::getResource)
             .orElseGet(() -> {
                 listener.ingredientsExhausted(resourceState.resource(), remaining);
                 return null;
@@ -192,7 +191,7 @@ class CraftingTree<T> {
     @Nullable
     private CraftingState.ResourceState cycleToNextIngredientOrFail(final IngredientState ingredientState,
                                                                     final ChildCalculationResult<T> childResult) {
-        return ingredientState.cycle().map(craftingState::getResource).orElseGet(() -> {
+        return ingredientState.cycle().orElseGet(() -> {
             this.craftingState = childResult.childTree.craftingState;
             listener.childCalculationCompleted(childResult.childTree.listener);
             return null;

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/IngredientState.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/IngredientState.java
@@ -8,20 +8,20 @@ import java.util.Optional;
 
 class IngredientState {
     private final long amount;
-    private final ResourceKey[] possibilities;
+    private final CraftingState.ResourceState[] possibilities;
     private int pos;
 
     IngredientState(final Ingredient ingredient, final CraftingState state) {
         this.amount = ingredient.amount();
-        this.possibilities = new ResourceKey[ingredient.inputs().size()];
+        this.possibilities = new CraftingState.ResourceState[ingredient.inputs().size()];
         for (int i = 0; i < ingredient.inputs().size(); i++) {
             final ResourceKey resource = ingredient.inputs().get(i);
-            possibilities[i] = resource;
+            possibilities[i] = state.getResource(resource);
         }
-        Arrays.sort(possibilities, state.getSorter());
+        Arrays.sort(possibilities);
     }
 
-    ResourceKey get() {
+    CraftingState.ResourceState get() {
         return possibilities[pos];
     }
 
@@ -29,11 +29,11 @@ class IngredientState {
         return amount;
     }
 
-    Optional<ResourceKey> cycle() {
+    Optional<CraftingState.ResourceState> cycle() {
         if (pos + 1 >= possibilities.length) {
             return Optional.empty();
         }
         pos++;
-        return Optional.of(get());
+        return Optional.of(possibilities[pos]);
     }
 }

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/preview/PreviewBuilder.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/preview/PreviewBuilder.java
@@ -11,11 +11,16 @@ import java.util.List;
 import java.util.Map;
 
 public class PreviewBuilder {
-    private final Map<ResourceKey, MutablePreviewItem> items = new LinkedHashMap<>();
+    private final Map<ResourceKey, MutablePreviewItem> items;
     private List<ResourceAmount> outputsOfPatternWithCycle = Collections.emptyList();
     private boolean missing;
 
     private PreviewBuilder() {
+        items = new LinkedHashMap<>();
+    }
+
+    private PreviewBuilder(final int size) {
+        items = LinkedHashMap.newLinkedHashMap(size);
     }
 
     public static PreviewBuilder create() {
@@ -51,7 +56,7 @@ public class PreviewBuilder {
     }
 
     public PreviewBuilder copy() {
-        final PreviewBuilder copy = new PreviewBuilder();
+        final PreviewBuilder copy = new PreviewBuilder(items.size());
         for (final Map.Entry<ResourceKey, MutablePreviewItem> entry : items.entrySet()) {
             final MutablePreviewItem item = entry.getValue();
             copy.items.put(entry.getKey(), item.copy());

--- a/refinedstorage-resource-api/src/main/java/com/refinedmods/refinedstorage/api/resource/list/LazyCopyMutableResourceList.java
+++ b/refinedstorage-resource-api/src/main/java/com/refinedmods/refinedstorage/api/resource/list/LazyCopyMutableResourceList.java
@@ -1,0 +1,112 @@
+package com.refinedmods.refinedstorage.api.resource.list;
+
+import com.refinedmods.refinedstorage.api.resource.ResourceAmount;
+import com.refinedmods.refinedstorage.api.resource.ResourceKey;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+import org.apiguardian.api.API;
+
+/**
+ * An implementation of a {@link ResourceList} that lazily copies from an original list.
+ * Only the entries that are changed are copied.
+ */
+@API(status = API.Status.STABLE, since = "2.0.0-beta.11")
+public class LazyCopyMutableResourceList implements MutableResourceList {
+    private final MutableResourceList original;
+    private final MutableResourceList updates;
+    private final Set<ResourceKey> pulled;
+
+    private LazyCopyMutableResourceList(final MutableResourceList original, final MutableResourceList updates,
+                                        final Set<ResourceKey> pulled) {
+        this.original = original;
+        this.updates = updates;
+        this.pulled = pulled;
+    }
+
+    public static LazyCopyMutableResourceList create(final MutableResourceList original) {
+        return new LazyCopyMutableResourceList(original, MutableResourceListImpl.create(), new HashSet<>());
+    }
+
+    @Override
+    public OperationResult add(final ResourceKey resource, final long amount) {
+        ResourceAmount.validate(resource, amount);
+        pullIntoUpdates(resource);
+        return updates.add(resource, amount);
+    }
+
+    private void pullIntoUpdates(final ResourceKey resource) {
+        if (!pulled.add(resource)) {
+            return;
+        }
+        final long amount = original.get(resource);
+        if (amount > 0) {
+            updates.add(resource, amount);
+        }
+    }
+
+    @Nullable
+    @Override
+    public OperationResult remove(final ResourceKey resource, final long amount) {
+        ResourceAmount.validate(resource, amount);
+        pullIntoUpdates(resource);
+        return updates.remove(resource, amount);
+    }
+
+    @Override
+    public void clear() {
+        pulled.addAll(original.getAll());
+        updates.clear();
+    }
+
+    @Override
+    public MutableResourceList copy() {
+        return new LazyCopyMutableResourceList(original, updates.copy(), new HashSet<>(pulled));
+    }
+
+    @Override
+    public Collection<ResourceAmount> copyState() {
+        final Set<ResourceAmount> copy = new HashSet<>(original.copyState());
+        copy.removeIf(ra -> pulled.contains(ra.resource()));
+        copy.addAll(updates.copyState());
+        return Collections.unmodifiableSet(copy);
+    }
+
+    @Override
+    public Set<ResourceKey> getAll() {
+        final Set<ResourceKey> all = new HashSet<>(original.getAll());
+        all.removeAll(pulled);
+        all.addAll(updates.getAll());
+        return Collections.unmodifiableSet(all);
+    }
+
+    @Override
+    public long get(final ResourceKey resource) {
+        if (pulled.contains(resource)) {
+            return updates.get(resource);
+        }
+        return original.get(resource);
+    }
+
+    @Override
+    public boolean contains(final ResourceKey resource) {
+        if (pulled.contains(resource)) {
+            return updates.contains(resource);
+        }
+        return original.contains(resource);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return getAll().isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return original + " -> " + updates;
+    }
+}

--- a/refinedstorage-resource-api/src/main/java/com/refinedmods/refinedstorage/api/resource/list/MutableResourceListImpl.java
+++ b/refinedstorage-resource-api/src/main/java/com/refinedmods/refinedstorage/api/resource/list/MutableResourceListImpl.java
@@ -28,6 +28,12 @@ public class MutableResourceListImpl implements MutableResourceList {
         return new MutableResourceListImpl(new HashMap<>());
     }
 
+    private static MutableResourceListImpl createCopy(final Map<ResourceKey, Entry> entries) {
+        final Map<ResourceKey, Entry> newEntries = HashMap.newHashMap(entries.size());
+        entries.forEach((key, entry) -> newEntries.put(key, new Entry(key, entry.amount)));
+        return new MutableResourceListImpl(newEntries);
+    }
+
     public static MutableResourceListImpl orderPreserving() {
         return new MutableResourceListImpl(new LinkedHashMap<>());
     }
@@ -117,9 +123,7 @@ public class MutableResourceListImpl implements MutableResourceList {
 
     @Override
     public MutableResourceList copy() {
-        final MutableResourceList copy = MutableResourceListImpl.create();
-        entries.forEach((key, entry) -> copy.add(key, entry.amount));
-        return copy;
+        return MutableResourceListImpl.createCopy(entries);
     }
 
     @Override

--- a/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/AbstractMutableResourceListTest.java
+++ b/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/AbstractMutableResourceListTest.java
@@ -6,32 +6,27 @@ import com.refinedmods.refinedstorage.api.resource.TestResource;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ExtendWith(InitialStateExtension.class)
 abstract class AbstractMutableResourceListTest {
-    protected MutableResourceList sut;
 
-    @BeforeEach
-    void setUp() {
-        sut = createList();
-    }
-
-    protected abstract MutableResourceList createList();
+    protected abstract MutableResourceList createList(TestResource[] resources, long amount);
 
     @Test
-    void testInitialState() {
+    void testInitialState(final MutableResourceList sut) {
         // Assert
         assertThat(sut.copyState()).isEmpty();
         assertThat(sut.isEmpty()).isTrue();
     }
 
     @Test
-    void shouldAddNewResource() {
+    void shouldAddNewResource(final MutableResourceList sut) {
         // Act
         final MutableResourceList.OperationResult result = sut.add(TestResource.A, 10);
 
@@ -51,7 +46,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldAddNewResourceWithResourceAmountDirectly() {
+    void shouldAddNewResourceWithResourceAmountDirectly(final MutableResourceList sut) {
         // Act
         final MutableResourceList.OperationResult result = sut.add(new ResourceAmount(TestResource.A, 10));
 
@@ -71,7 +66,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldAddMultipleOfSameResource() {
+    void shouldAddMultipleOfSameResource(final MutableResourceList sut) {
         // Act
         final MutableResourceList.OperationResult result1 = sut.add(TestResource.A, 10);
         final MutableResourceList.OperationResult result2 = sut.add(TestResource.A, 5);
@@ -97,7 +92,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldAddMultipleOfDifferentResources() {
+    void shouldAddMultipleOfDifferentResources(final MutableResourceList sut) {
         // Act
         final MutableResourceList.OperationResult result1 = sut.add(TestResource.A, 10);
         final MutableResourceList.OperationResult result2 = sut.add(TestResource.A, 5);
@@ -133,7 +128,7 @@ abstract class AbstractMutableResourceListTest {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    void shouldNotAddInvalidResourceOrAmount() {
+    void shouldNotAddInvalidResourceOrAmount(final MutableResourceList sut) {
         // Act
         final Executable action1 = () -> sut.add(TestResource.A, 0);
         final Executable action2 = () -> sut.add(TestResource.A, -1);
@@ -146,7 +141,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldNotRemoveResourceWhenItIsNotAvailable() {
+    void shouldNotRemoveResourceWhenItIsNotAvailable(final MutableResourceList sut) {
         // Act
         final MutableResourceList.OperationResult result = sut.remove(TestResource.A, 10);
 
@@ -155,7 +150,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldRemoveResourcePartly() {
+    void shouldRemoveResourcePartly(final MutableResourceList sut) {
         // Arrange
         sut.add(TestResource.A, 20);
         sut.add(TestResource.B, 6);
@@ -184,7 +179,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldRemoveResourcePartlyWithResourceAmount() {
+    void shouldRemoveResourcePartlyWithResourceAmount(final MutableResourceList sut) {
         // Arrange
         sut.add(TestResource.A, 20);
         sut.add(TestResource.B, 6);
@@ -216,7 +211,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldRemoveResourceCompletely() {
+    void shouldRemoveResourceCompletely(final MutableResourceList sut) {
         // Arrange
         sut.add(TestResource.A, 20);
         sut.add(TestResource.B, 6);
@@ -244,7 +239,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldRemoveResourceCompletelyWithResourceAmount() {
+    void shouldRemoveResourceCompletelyWithResourceAmount(final MutableResourceList sut) {
         // Arrange
         sut.add(TestResource.A, 20);
         sut.add(TestResource.B, 6);
@@ -275,7 +270,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldRemoveLastResourceOfResourceList() {
+    void shouldRemoveLastResourceOfResourceList(final MutableResourceList sut) {
         // Arrange
         sut.add(TestResource.A, 1);
 
@@ -297,7 +292,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldNotRemoveResourceWithMoreThanIsAvailable() {
+    void shouldNotRemoveResourceWithMoreThanIsAvailable(final MutableResourceList sut) {
         // Arrange
         sut.add(TestResource.A, 20);
         sut.add(TestResource.B, 6);
@@ -326,7 +321,7 @@ abstract class AbstractMutableResourceListTest {
 
     @Test
     @SuppressWarnings("ConstantConditions")
-    void shouldNotRemoveInvalidResourceOrAmount() {
+    void shouldNotRemoveInvalidResourceOrAmount(final MutableResourceList sut) {
         // Act
         final Executable action1 = () -> sut.remove(TestResource.A, 0);
         final Executable action2 = () -> sut.remove(TestResource.A, -1);
@@ -339,7 +334,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldClearList() {
+    void shouldClearList(final MutableResourceList sut) {
         // Arrange
         sut.add(TestResource.A, 10);
         sut.add(TestResource.B, 5);
@@ -362,7 +357,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void shouldCopyList() {
+    void shouldCopyList(final MutableResourceList sut) {
         // Arrange
         sut.add(TestResource.A, 10);
         sut.add(TestResource.B, 5);
@@ -392,7 +387,7 @@ abstract class AbstractMutableResourceListTest {
     }
 
     @Test
-    void testToString() {
+    void testToString(final MutableResourceList sut) {
         // Arrange
         sut.add(TestResource.A, 10);
         sut.add(TestResource.B, 5);

--- a/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/InitialState.java
+++ b/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/InitialState.java
@@ -1,0 +1,15 @@
+package com.refinedmods.refinedstorage.api.resource.list;
+
+import com.refinedmods.refinedstorage.api.resource.TestResource;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InitialState {
+    TestResource[] value() default {};
+    long amount() default 1;
+}

--- a/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/InitialStateExtension.java
+++ b/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/InitialStateExtension.java
@@ -1,0 +1,37 @@
+package com.refinedmods.refinedstorage.api.resource.list;
+
+import com.refinedmods.refinedstorage.api.resource.TestResource;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class InitialStateExtension implements ParameterResolver {
+    @Override
+    public boolean supportsParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext)
+        throws ParameterResolutionException {
+        return MutableResourceList.class.isAssignableFrom(parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(final ParameterContext parameterContext, final ExtensionContext extensionContext)
+        throws ParameterResolutionException {
+        final Optional<InitialState> annotation = parameterContext.findAnnotation(InitialState.class);
+        final TestResource[] initialState = annotation
+            .map(InitialState::value)
+            .orElse(new TestResource[0]);
+        final long amount = annotation.map(InitialState::amount).orElse(0L);
+        final Class<?> declaringClass = parameterContext.getDeclaringExecutable().getDeclaringClass();
+        try {
+            final Method createList = declaringClass.getDeclaredMethod("createList", TestResource[].class, long.class);
+            return createList.invoke(extensionContext.getTestInstance().orElseThrow(), initialState, amount);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            throw new ParameterResolutionException("createList method could not be invoked", e);
+        }
+    }
+}

--- a/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/LazyCopyMutableResourceListTest.java
+++ b/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/LazyCopyMutableResourceListTest.java
@@ -1,0 +1,98 @@
+package com.refinedmods.refinedstorage.api.resource.list;
+
+import com.refinedmods.refinedstorage.api.resource.TestResource;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LazyCopyMutableResourceListTest extends AbstractMutableResourceListTest {
+    @Override
+    protected MutableResourceList createList(final TestResource[] resources, final long amount) {
+        final MutableResourceListImpl original = MutableResourceListImpl.create();
+        for (final TestResource resource : resources) {
+            original.add(resource, amount);
+        }
+        return LazyCopyMutableResourceList.create(original);
+    }
+
+    @Test
+    void shouldGetFromOriginal(@InitialState({TestResource.A}) final MutableResourceList sut) {
+        // Act + Assert
+        assertThat(sut.get(TestResource.A)).isEqualTo(1);
+        assertThat(sut.contains(TestResource.A)).isTrue();
+        assertThat(sut.isEmpty()).isFalse();
+        assertThat(sut.getAll()).containsExactly(TestResource.A);
+    }
+
+    @Test
+    void shouldAddCorrectly(@InitialState({TestResource.A}) final MutableResourceList sut) {
+        // Act
+        final MutableResourceList.OperationResult add = sut.add(TestResource.A, 1);
+        // Assert
+        assertThat(add.change()).isEqualTo(1);
+        assertThat(add.amount()).isEqualTo(2);
+        assertThat(add.resource()).isEqualTo(TestResource.A);
+        assertThat(add.available()).isTrue();
+        assertThat(sut.get(TestResource.A)).isEqualTo(2);
+    }
+
+    @Test
+    void shouldRemoveCorrectly(
+        @InitialState(value = {TestResource.A, TestResource.B, TestResource.C}, amount = 4)
+        final MutableResourceList sut) {
+        // Act
+        final MutableResourceList.OperationResult removeA = sut.remove(TestResource.A, 10);
+        final MutableResourceList.OperationResult removeB = sut.remove(TestResource.B, 3);
+        final MutableResourceList.OperationResult removeC = sut.remove(TestResource.C, 4);
+        // Assert
+        assertThat(removeA).isNotNull();
+        assertThat(removeA.amount()).isEqualTo(0);
+        assertThat(removeA.resource()).isEqualTo(TestResource.A);
+        assertThat(removeA.change()).isEqualTo(-4);
+        assertThat(removeA.available()).isFalse();
+        assertThat(sut.get(TestResource.A)).isEqualTo(0);
+
+        assertThat(removeB).isNotNull();
+        assertThat(removeB.amount()).isEqualTo(1);
+        assertThat(removeB.change()).isEqualTo(-3);
+        assertThat(removeB.resource()).isEqualTo(TestResource.B);
+        assertThat(removeB.available()).isTrue();
+
+        assertThat(removeC).isNotNull();
+        assertThat(removeC.amount()).isEqualTo(0);
+        assertThat(removeC.change()).isEqualTo(-4);
+        assertThat(removeC.resource()).isEqualTo(TestResource.C);
+        assertThat(removeC.available()).isFalse();
+    }
+
+    @Test
+    void shouldAddRemoveCorrectlyWithInitial(@InitialState({TestResource.A}) final MutableResourceList sut) {
+        // Act
+        final MutableResourceList.OperationResult add = sut.add(TestResource.A, 1);
+        final MutableResourceList.OperationResult remove = sut.remove(TestResource.A, 3);
+        // Assert
+        assertThat(add.change()).isEqualTo(1);
+        assertThat(add.amount()).isEqualTo(2);
+        assertThat(add.available()).isTrue();
+        assertThat(remove).isNotNull();
+        assertThat(remove.change()).isEqualTo(-2);
+        assertThat(remove.amount()).isEqualTo(0);
+        assertThat(remove.available()).isFalse();
+    }
+
+    @Test
+    void shouldRemoveAddCorrectlyWithInitial(@InitialState({TestResource.A}) final MutableResourceList sut) {
+        // Act
+        final MutableResourceList.OperationResult remove = sut.remove(TestResource.A, 3);
+        final MutableResourceList.OperationResult add = sut.add(TestResource.A, 3);
+        // Assert
+        assertThat(remove).isNotNull();
+        assertThat(remove.change()).isEqualTo(-1);
+        assertThat(remove.amount()).isEqualTo(0);
+        assertThat(remove.available()).isFalse();
+        assertThat(add.change()).isEqualTo(3);
+        assertThat(add.amount()).isEqualTo(3);
+        assertThat(add.available()).isTrue();
+    }
+}

--- a/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/MutableResourceListImplTest.java
+++ b/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/MutableResourceListImplTest.java
@@ -1,8 +1,14 @@
 package com.refinedmods.refinedstorage.api.resource.list;
 
+import com.refinedmods.refinedstorage.api.resource.TestResource;
+
 class MutableResourceListImplTest extends AbstractMutableResourceListTest {
     @Override
-    protected MutableResourceList createList() {
-        return MutableResourceListImpl.create();
+    protected MutableResourceList createList(final TestResource[] resources, final long amount) {
+        final MutableResourceListImpl mutableResourceList = MutableResourceListImpl.create();
+        for (final TestResource resource : resources) {
+            mutableResourceList.add(resource, amount);
+        }
+        return mutableResourceList;
     }
 }

--- a/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/OrderPreservingMutableResourceListImplTest.java
+++ b/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/OrderPreservingMutableResourceListImplTest.java
@@ -2,6 +2,7 @@ package com.refinedmods.refinedstorage.api.resource.list;
 
 import com.refinedmods.refinedstorage.api.resource.ResourceAmount;
 import com.refinedmods.refinedstorage.api.resource.ResourceKey;
+import com.refinedmods.refinedstorage.api.resource.TestResource;
 
 import java.util.Collection;
 import java.util.Set;
@@ -15,12 +16,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class OrderPreservingMutableResourceListImplTest extends AbstractMutableResourceListTest {
     @Override
-    protected MutableResourceList createList() {
-        return MutableResourceListImpl.orderPreserving();
+    protected MutableResourceList createList(final TestResource[] resources, final long amount) {
+        final MutableResourceListImpl mutableResourceList = MutableResourceListImpl.orderPreserving();
+        for (final TestResource resource : resources) {
+            mutableResourceList.add(resource, amount);
+        }
+        return mutableResourceList;
     }
 
     @Test
-    void shouldPreserveOrderWhenRetrievingKeys() {
+    void shouldPreserveOrderWhenRetrievingKeys(final MutableResourceList sut) {
         // Arrange
         sut.add(A, 1);
         sut.add(B, 1);
@@ -34,7 +39,7 @@ class OrderPreservingMutableResourceListImplTest extends AbstractMutableResource
     }
 
     @Test
-    void shouldPreserveOrderWhenCopyingState() {
+    void shouldPreserveOrderWhenCopyingState(final MutableResourceList sut) {
         // Arrange
         sut.add(A, 1);
         sut.add(B, 1);

--- a/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/ProxyResourceListTest.java
+++ b/refinedstorage-resource-api/src/test/java/com/refinedmods/refinedstorage/api/resource/list/ProxyResourceListTest.java
@@ -1,9 +1,15 @@
 package com.refinedmods.refinedstorage.api.resource.list;
 
+import com.refinedmods.refinedstorage.api.resource.TestResource;
+
 class ProxyResourceListTest extends AbstractMutableResourceListTest {
     @Override
-    protected MutableResourceList createList() {
-        return new AbstractProxyMutableResourceList(MutableResourceListImpl.create()) {
+    protected MutableResourceList createList(final TestResource[] resources, final long amount) {
+        final MutableResourceListImpl delegate = MutableResourceListImpl.create();
+        for (final TestResource resource : resources) {
+            delegate.add(resource, amount);
+        }
+        return new AbstractProxyMutableResourceList(delegate) {
         };
     }
 }


### PR DESCRIPTION
Also related to #1100, but while this change provides significant speedups, timeouts are still common when materials are missing.

One main observation is that we most likely don't touch most of the material in the system. Consequently, if we track the changes on top of the original system state, we can reduce copies to what the actual changes.

On top of that, we can avoid HashMap resizing by pre-sizing them better and we can also avoid lookups when copying as described in #956.

In my testings, even complex recipes get calculated when enough material is present. With material is missing, it is also a lot faster, but noticeably slower.