### PR TITLE
perf: prevent unnecessary redstone checks in network node logic

### DIFF
--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/detector/DetectorBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/detector/DetectorBlockEntity.java
@@ -181,4 +181,10 @@ public class DetectorBlockEntity extends AbstractBaseNetworkNodeContainerBlockEn
                                                                    final BlockState newBlockState) {
         return AbstractDirectionalBlock.didDirectionChange(oldBlockState, newBlockState);
     }
+
+    @Override
+    protected boolean hasRedstoneMode() {
+        return false;
+    }
+
 }

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/AbstractCableBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/AbstractCableBlockEntity.java
@@ -20,4 +20,9 @@ public abstract class AbstractCableBlockEntity extends AbstractCableLikeBlockEnt
     public Component getName() {
         return overrideName(ContentNames.CABLE);
     }
+
+    @Override
+    protected boolean hasRedstoneMode() {
+        return false;
+    }
 }

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/network/AbstractBaseNetworkNodeContainerBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/network/AbstractBaseNetworkNodeContainerBlockEntity.java
@@ -81,6 +81,7 @@ public abstract class AbstractBaseNetworkNodeContainerBlockEntity<T extends Abst
         final long energyUsage = mainNetworkNode.getEnergyUsage();
         final boolean hasLevel = level != null && level.isLoaded(worldPosition);
         final boolean redstoneModeActive = !hasRedstoneMode()
+            || this.redstoneMode == RedstoneMode.IGNORE
             || redstoneMode.isActive(hasLevel && level.hasNeighborSignal(worldPosition));
         return hasLevel
             && redstoneModeActive


### PR DESCRIPTION
### **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduces a performance improvement in the logic of the redstone activeness check of ``com.refinedmods.refinedstorage.common.support.network.AbstractBaseNetworkNodeContainerBlockEntity@calculateActive()`` .

### **What is the current behavior?** (You can also link to an open issue here)
In the current logic, the Base BlockEntity for all network node blocks, (including but not limited to cables, controllers, importers, etc.) will check and request if the block is being powered by redstone, even if that block has a Redstone Active mode of IGNORE.

This means that blocks like cables or importers which have the mode IGNORE, and which might not even be changed from IGNORE to HIGH/LOW, will perform many costly calculations to check if what the value of the redstone signal is, despite the results of this check not being used later in the process, as IGNORE is hardcoded to return ``true``.

This can mean that even on a simple flat world with a lot of cables and no further blocks, a large performance overhead is present due to the many redstone activeness checks.

### **What is the new behavior?**
In the new logic, the hardcoded check for redstone active mode IGNORE is placed in ``AbstractBaseNetworkNodeContainerBlockEntity@calculateActive`` before the code to request the current redstone signal is executed.

In practice this means the performance overhead of cables and other blocks, like importers, can be significantly decreased. In the playtesting on our world this resulted in a decrease in the time spend per tick, which saved around 4 seconds worth of checks to determine the redstone status of these blocks per minute. Which is around 1.68 processing hours per 24h day saved in unnecessary checks.


### **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
This PR does not introduce a breaking change, as it only slightly changes the order in which the behaviour is determined. It does not impact any features or behaviour.


### **Other information**:
There is no open issue as far as I am aware. I had introduced  the fix already, so I figured I'd save the time writing an issue.

We discovered this performance issue after we began running into issues of server tick rate after most our friend group had migrated to refined storage to access Sophisticated Storage inventories over a longer distance with a combination of crafting grids and external interfaces.

Upon tests using profilers and multiple test setups, including unpowered networks, we found the issue to be with the ``level.hasNeighborSignal(worldPosition));`` call. We were able to replicate this in a clean install of the mod and test worlds, and found the line that is the culprit.

The fix itself is not the cleanest, as it does technically leave the check in  ``com.refinedmods.refinedstorage.common.support.RedstoneMode@isActive()`` as well. However, I've left the old behaviour in there as well so ``com.refinedmods.refinedstorage.common.storage.portablegrid.InWorldPortableGrid@isGridActive()`` wouldn't need to be changed. If you want me to change anything, or move it into a method in the RedstoneMode enum, I'd be happy to do that! :slightly_smiling_face: 

I've also not added this to the release notes, as I am not sure whether this technical change would be relevant enough for the end-user.