### PR TITLE
fix: concurrent access to listeners when scheduling task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -   Duplicating storage disks with middle click in creative mode will now give a new storage disk instead of referencing the copied one.
 
+### Fixed
+
+-   Rare crash when starting an autocrafting task.
+
 ## [2.0.0-beta.11] - 2025-08-25
 
 ### Added

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/preview/PreviewProvider.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/preview/PreviewProvider.java
@@ -20,6 +20,6 @@ public interface PreviewProvider {
 
     CompletableFuture<Long> getMaxAmount(ResourceKey resource, CancellationToken cancellationToken);
 
-    CompletableFuture<Optional<TaskId>> startTask(ResourceKey resource, long amount, Actor actor, boolean notify,
-                                                  CancellationToken cancellationToken);
+    Optional<TaskId> startTask(ResourceKey resource, long amount, Actor actor, boolean notify,
+                               CancellationToken cancellationToken);
 }

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/AbstractGridBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/AbstractGridBlockEntity.java
@@ -138,14 +138,14 @@ public abstract class AbstractGridBlockEntity extends AbstractBaseNetworkNodeCon
     }
 
     @Override
-    public CompletableFuture<Optional<TaskId>> startTask(final ResourceKey resource,
-                                                         final long amount,
-                                                         final Actor actor,
-                                                         final boolean notify,
-                                                         final CancellationToken cancellationToken) {
+    public Optional<TaskId> startTask(final ResourceKey resource,
+                                      final long amount,
+                                      final Actor actor,
+                                      final boolean notify,
+                                      final CancellationToken cancellationToken) {
         final Network network = mainNetworkNode.getNetwork();
         if (network == null) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return Optional.empty();
         }
         return network.getComponent(AutocraftingNetworkComponent.class).startTask(resource, amount, actor, notify,
             cancellationToken);

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/AbstractGridContainerMenu.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/AbstractGridContainerMenu.java
@@ -528,15 +528,12 @@ public abstract class AbstractGridContainerMenu extends AbstractResourceContaine
     }
 
     @Override
-    public CompletableFuture<Optional<TaskId>> startTask(final ResourceKey resource,
-                                                         final long amount,
-                                                         final Actor actor,
-                                                         final boolean notify,
-                                                         final CancellationToken cancellationToken) {
-        final CompletableFuture<Optional<TaskId>> taskRequest = requireNonNull(grid).startTask(resource, amount, actor,
-            notify, cancellationToken);
-        pendingAutocraftingRequests.add(taskRequest, cancellationToken);
-        return taskRequest;
+    public Optional<TaskId> startTask(final ResourceKey resource,
+                                      final long amount,
+                                      final Actor actor,
+                                      final boolean notify,
+                                      final CancellationToken cancellationToken) {
+        return requireNonNull(grid).startTask(resource, amount, actor, notify, cancellationToken);
     }
 
     @Override

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/ClientCraftingGrid.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/ClientCraftingGrid.java
@@ -131,11 +131,11 @@ class ClientCraftingGrid implements CraftingGrid {
     }
 
     @Override
-    public CompletableFuture<Optional<TaskId>> startTask(final ResourceKey resource,
-                                                         final long amount,
-                                                         final Actor actor,
-                                                         final boolean notify,
-                                                         final CancellationToken cancellationToken) {
+    public Optional<TaskId> startTask(final ResourceKey resource,
+                                      final long amount,
+                                      final Actor actor,
+                                      final boolean notify,
+                                      final CancellationToken cancellationToken) {
         throw new UnsupportedOperationException();
     }
 }

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/WirelessGrid.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/WirelessGrid.java
@@ -154,13 +154,12 @@ class WirelessGrid implements Grid {
     }
 
     @Override
-    public CompletableFuture<Optional<TaskId>> startTask(final ResourceKey resource,
-                                                         final long amount,
-                                                         final Actor actor,
-                                                         final boolean notify,
-                                                         final CancellationToken cancellationToken) {
-        return getAutocrafting()
-            .map(autocrafting -> autocrafting.startTask(resource, amount, actor, notify, cancellationToken))
-            .orElse(CompletableFuture.completedFuture(Optional.empty()));
+    public Optional<TaskId> startTask(final ResourceKey resource,
+                                      final long amount,
+                                      final Actor actor,
+                                      final boolean notify,
+                                      final CancellationToken cancellationToken) {
+        return getAutocrafting().flatMap(
+            autocrafting -> autocrafting.startTask(resource, amount, actor, notify, cancellationToken));
     }
 }

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/storage/portablegrid/PortableGrid.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/storage/portablegrid/PortableGrid.java
@@ -159,11 +159,11 @@ class PortableGrid implements Grid {
     }
 
     @Override
-    public CompletableFuture<Optional<TaskId>> startTask(final ResourceKey resource,
-                                                         final long amount,
-                                                         final Actor actor,
-                                                         final boolean notify,
-                                                         final CancellationToken cancellationToken) {
-        return CompletableFuture.completedFuture(Optional.empty());
+    public Optional<TaskId> startTask(final ResourceKey resource,
+                                      final long amount,
+                                      final Actor actor,
+                                      final boolean notify,
+                                      final CancellationToken cancellationToken) {
+        return Optional.empty();
     }
 }

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/storagemonitor/AutocraftingStorageMonitorContainerMenu.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/storagemonitor/AutocraftingStorageMonitorContainerMenu.java
@@ -75,15 +75,12 @@ public class AutocraftingStorageMonitorContainerMenu extends AutocraftingPreview
     }
 
     @Override
-    public CompletableFuture<Optional<TaskId>> startTask(final ResourceKey resource,
-                                                         final long amount,
-                                                         final Actor actor,
-                                                         final boolean notify,
-                                                         final CancellationToken cancellationToken) {
-        final CompletableFuture<Optional<TaskId>> taskRequest = requireNonNull(storageMonitor).startTask(resource,
-            amount, actor, notify, cancellationToken);
-        pendingAutocraftingRequests.add(taskRequest, cancellationToken);
-        return taskRequest;
+    public Optional<TaskId> startTask(final ResourceKey resource,
+                                      final long amount,
+                                      final Actor actor,
+                                      final boolean notify,
+                                      final CancellationToken cancellationToken) {
+        return requireNonNull(storageMonitor).startTask(resource, amount, actor, notify, cancellationToken);
     }
 
     @Override

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/storagemonitor/StorageMonitorBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/storagemonitor/StorageMonitorBlockEntity.java
@@ -398,14 +398,14 @@ public class StorageMonitorBlockEntity extends AbstractBaseNetworkNodeContainerB
     }
 
     @Override
-    public CompletableFuture<Optional<TaskId>> startTask(final ResourceKey resource,
-                                                         final long amount,
-                                                         final Actor actor,
-                                                         final boolean notify,
-                                                         final CancellationToken cancellationToken) {
+    public Optional<TaskId> startTask(final ResourceKey resource,
+                                      final long amount,
+                                      final Actor actor,
+                                      final boolean notify,
+                                      final CancellationToken cancellationToken) {
         final Network network = mainNetworkNode.getNetwork();
         if (network == null) {
-            return CompletableFuture.completedFuture(Optional.empty());
+            return Optional.empty();
         }
         return network.getComponent(AutocraftingNetworkComponent.class).startTask(resource, amount, actor, notify,
             cancellationToken);

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/packet/c2s/AutocraftingRequestPacket.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/packet/c2s/AutocraftingRequestPacket.java
@@ -40,9 +40,9 @@ public record AutocraftingRequestPacket(UUID id,
         final Player player = ctx.getPlayer();
         if (player.containerMenu instanceof PreviewProvider provider) {
             final PlayerActor playerActor = new PlayerActor(player);
-            provider.startTask(packet.resource, packet.amount, playerActor, packet.notifyPlayer,
-                new TimeoutableCancellationToken()).thenAccept(taskId ->
-                S2CPackets.sendAutocraftingResponse((ServerPlayer) player, packet.id, taskId.isPresent()));
+            final var taskId = provider.startTask(packet.resource, packet.amount, playerActor, packet.notifyPlayer,
+                new TimeoutableCancellationToken());
+            S2CPackets.sendAutocraftingResponse((ServerPlayer) player, packet.id, taskId.isPresent());
         }
     }
 

--- a/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/autocrafting/AutocraftingNetworkComponentImpl.java
+++ b/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/autocrafting/AutocraftingNetworkComponentImpl.java
@@ -158,40 +158,16 @@ public class AutocraftingNetworkComponentImpl implements AutocraftingNetworkComp
     }
 
     @Override
-    public CompletableFuture<Optional<TaskId>> startTask(final ResourceKey resource,
-                                                         final long amount,
-                                                         final Actor actor,
-                                                         final boolean notify,
-                                                         final CancellationToken cancellationToken) {
+    public Optional<TaskId> startTask(final ResourceKey resource,
+                                      final long amount,
+                                      final Actor actor,
+                                      final boolean notify,
+                                      final CancellationToken cancellationToken) {
         ResourceAmount.validate(resource, amount);
-        return CompletableFuture.supplyAsync(() -> startTaskSync(resource, amount, actor, notify, cancellationToken),
-            executorService);
-    }
-
-    private TaskId startTask(final ResourceKey resource,
-                             final long amount,
-                             final Actor actor,
-                             final TaskPlan plan,
-                             final boolean notify) {
-        final Task task = new TaskImpl(plan, actor, notify);
-        LOGGER.debug("Created task {} for {}x {} for {}", task.getId(), amount, resource, actor);
-        final PatternProvider provider = CoreValidations.validateNotNull(
-            providerByPattern.get(plan.rootPattern()),
-            "No provider for pattern " + plan.rootPattern()
-        );
-        provider.addTask(task);
-        return task.getId();
-    }
-
-    private Optional<TaskId> startTaskSync(final ResourceKey resource,
-                                           final long amount,
-                                           final Actor actor,
-                                           final boolean notify,
-                                           final CancellationToken cancellationToken) {
         final RootStorage rootStorage = rootStorageProvider.get();
         final CraftingCalculator calculator = new CraftingCalculatorImpl(patternRepository, rootStorage);
         return calculatePlan(calculator, resource, amount, cancellationToken)
-            .map(plan -> startTask(resource, amount, actor, plan, notify));
+            .map(plan -> addTask(resource, amount, actor, plan, notify));
     }
 
     @Override
@@ -210,9 +186,27 @@ public class AutocraftingNetworkComponentImpl implements AutocraftingNetworkComp
         if (correctedAmount <= 0) {
             return EnsureResult.MISSING_RESOURCES;
         }
-        return startTaskSync(resource, correctedAmount, actor, false, CancellationToken.NONE)
+        final RootStorage rootStorage = rootStorageProvider.get();
+        final CraftingCalculator calculator = new CraftingCalculatorImpl(patternRepository, rootStorage);
+        return calculatePlan(calculator, resource, correctedAmount, CancellationToken.NONE)
+            .map(plan -> addTask(resource, correctedAmount, actor, plan, false))
             .map(taskId -> EnsureResult.TASK_CREATED)
             .orElse(EnsureResult.MISSING_RESOURCES);
+    }
+
+    private TaskId addTask(final ResourceKey resource,
+                           final long amount,
+                           final Actor actor,
+                           final TaskPlan plan,
+                           final boolean notify) {
+        final Task task = new TaskImpl(plan, actor, notify);
+        LOGGER.debug("Created task {} for {}x {} for {}", task.getId(), amount, resource, actor);
+        final PatternProvider provider = CoreValidations.validateNotNull(
+            providerByPattern.get(plan.rootPattern()),
+            "No provider for pattern " + plan.rootPattern()
+        );
+        provider.addTask(task);
+        return task.getId();
     }
 
     @Override

--- a/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/node/grid/GridWatcherManager.java
+++ b/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/node/grid/GridWatcherManager.java
@@ -14,9 +14,7 @@ import org.apiguardian.api.API;
  */
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.3.3")
 public interface GridWatcherManager {
-    void addWatcher(GridWatcher watcher,
-                    Class<? extends Actor> actorType,
-                    @Nullable RootStorage rootStorage);
+    void addWatcher(GridWatcher watcher, Class<? extends Actor> actorType, @Nullable RootStorage rootStorage);
 
     void attachAll(@Nullable RootStorage rootStorage);
 

--- a/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/autocrafting/AutocraftingNetworkComponentImplTest.java
+++ b/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/autocrafting/AutocraftingNetworkComponentImplTest.java
@@ -260,7 +260,7 @@ class AutocraftingNetworkComponentImplTest {
         sut.onContainerAdded(container);
 
         // Act
-        final Optional<TaskId> taskId = sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+        final Optional<TaskId> taskId = sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE);
 
         // Assert
         assertThat(taskId).isPresent();
@@ -300,7 +300,7 @@ class AutocraftingNetworkComponentImplTest {
         sut.onContainerAdded(() -> provider);
 
         // Act & assert
-        assertThat(sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
         final var result = sut.ensureTask(B, 10, Actor.EMPTY);
         assertThat(result).isEqualTo(AutocraftingNetworkComponent.EnsureResult.TASK_CREATED);
         final var result2 = sut.ensureTask(B, 10, Actor.EMPTY);
@@ -394,7 +394,7 @@ class AutocraftingNetworkComponentImplTest {
         final NetworkNodeContainer container = () -> provider;
         sut.onContainerAdded(container);
 
-        sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+        sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE);
 
         // Act
         final var result = sut.ensureTask(B, 1, Actor.EMPTY);
@@ -421,8 +421,8 @@ class AutocraftingNetworkComponentImplTest {
         provider2.setPattern(1, pattern().ingredient(A, 3).output(C, 1).build());
         sut.onContainerAdded(() -> provider2);
 
-        final Optional<TaskId> taskId1 = sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
-        final Optional<TaskId> taskId2 = sut.startTask(C, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+        final Optional<TaskId> taskId1 = sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE);
+        final Optional<TaskId> taskId2 = sut.startTask(C, 1, Actor.EMPTY, false, CancellationToken.NONE);
 
         assertThat(taskId1).isPresent();
         assertThat(taskId2).isPresent();
@@ -474,8 +474,8 @@ class AutocraftingNetworkComponentImplTest {
         provider2.setPattern(1, pattern().ingredient(A, 3).output(C, 1).build());
         sut.onContainerAdded(() -> provider2);
 
-        final Optional<TaskId> taskId1 = sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
-        final Optional<TaskId> taskId2 = sut.startTask(C, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+        final Optional<TaskId> taskId1 = sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE);
+        final Optional<TaskId> taskId2 = sut.startTask(C, 1, Actor.EMPTY, false, CancellationToken.NONE);
 
         assertThat(taskId1).isPresent();
         assertThat(taskId2).isPresent();
@@ -520,7 +520,7 @@ class AutocraftingNetworkComponentImplTest {
         sut.onContainerAdded(container);
 
         // Act
-        final Optional<TaskId> taskId = sut.startTask(B, 2, Actor.EMPTY, false, CancellationToken.NONE).join();
+        final Optional<TaskId> taskId = sut.startTask(B, 2, Actor.EMPTY, false, CancellationToken.NONE);
 
         // Assert
         assertThat(taskId).isEmpty();
@@ -545,10 +545,10 @@ class AutocraftingNetworkComponentImplTest {
         provider3.setPattern(1, pattern().ingredient(A, 3).output(D, 1).build());
         sut.onContainerAdded(() -> provider3);
 
-        final Optional<TaskId> taskId1 = sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
-        final Optional<TaskId> taskId2 = sut.startTask(C, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+        final Optional<TaskId> taskId1 = sut.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE);
+        final Optional<TaskId> taskId2 = sut.startTask(C, 1, Actor.EMPTY, false, CancellationToken.NONE);
 
-        sut.startTask(D, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+        sut.startTask(D, 1, Actor.EMPTY, false, CancellationToken.NONE);
         sut.onContainerRemoved(() -> provider3);
 
         // Act

--- a/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/node/patternprovider/PatternProviderNetworkNodeTest.java
+++ b/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/node/patternprovider/PatternProviderNetworkNodeTest.java
@@ -145,7 +145,7 @@ class PatternProviderNetworkNodeTest {
         storage.insert(A, 10, Action.EXECUTE, Actor.EMPTY);
 
         sut.setPattern(1, pattern().ingredient(A, 3).output(B, 1).build());
-        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         // Act
         sut.setNetwork(null);
@@ -168,7 +168,7 @@ class PatternProviderNetworkNodeTest {
         storage.insert(A, 10, Action.EXECUTE, Actor.EMPTY);
 
         sut.setPattern(1, pattern().ingredient(A, 3).output(B, 1).build());
-        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         // Act
         sut.setActive(false);
@@ -191,7 +191,7 @@ class PatternProviderNetworkNodeTest {
         storage.insert(A, 10, Action.EXECUTE, Actor.EMPTY);
 
         sut.setPattern(1, pattern().ingredient(A, 3).output(B, 1).build());
-        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         // Act & assert
         assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(
@@ -230,7 +230,7 @@ class PatternProviderNetworkNodeTest {
         });
 
         sut.setPattern(1, pattern().ingredient(A, 3).output(B, 1).build());
-        assertThat(autocrafting.startTask(B, 20, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(autocrafting.startTask(B, 20, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         // Act & assert
         assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(
@@ -268,7 +268,7 @@ class PatternProviderNetworkNodeTest {
 
         sut.setPattern(1, pattern(PatternType.EXTERNAL).ingredient(A, 3).output(B, 1).build());
         sut.setSink(sink);
-        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         // Act & assert
         assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(
@@ -310,7 +310,7 @@ class PatternProviderNetworkNodeTest {
 
         sut.setPattern(1, pattern(PatternType.EXTERNAL).ingredient(A, 3).output(B, 1).build());
         sut.setSink((resources, action) -> ExternalPatternSink.Result.REJECTED);
-        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         // Act & assert
         assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(
@@ -348,7 +348,7 @@ class PatternProviderNetworkNodeTest {
         storage.insert(A, 10, Action.EXECUTE, Actor.EMPTY);
 
         sut.setPattern(1, pattern(PatternType.EXTERNAL).ingredient(A, 3).output(B, 1).build());
-        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(autocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         // Act & assert
         assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(
@@ -393,7 +393,7 @@ class PatternProviderNetworkNodeTest {
         sut.setListener(listener);
 
         // Act & assert
-        assertThat(autocrafting.startTask(B, 10, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(autocrafting.startTask(B, 10, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         sut.doWork();
         assertThat(sut.getTasks()).hasSize(1);
@@ -493,7 +493,7 @@ class PatternProviderNetworkNodeTest {
         sut.setSink((resources, action) -> ExternalPatternSink.Result.ACCEPTED);
 
         // Act & assert
-        assertThat(autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         sut.doWork();
         assertThat(sut.getTasks()).hasSize(1);
@@ -533,7 +533,7 @@ class PatternProviderNetworkNodeTest {
         sut.setSink((resources, action) -> ExternalPatternSink.Result.ACCEPTED);
 
         // Act & assert
-        assertThat(autocrafting.startTask(C, 3, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(autocrafting.startTask(C, 3, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         sut.doWork();
         assertThat(sut.getTasks()).hasSize(1);
@@ -628,7 +628,7 @@ class PatternProviderNetworkNodeTest {
         sut.setPattern(1, PATTERN_A);
 
         // Act
-        final var taskId = autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+        final var taskId = autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE);
 
         // Assert
         assertThat(taskId).isPresent();
@@ -649,7 +649,7 @@ class PatternProviderNetworkNodeTest {
         sut.setPattern(1, PATTERN_A);
 
         // Act
-        final var taskId = autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+        final var taskId = autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE);
 
         // Assert
         assertThat(taskId).isEmpty();
@@ -672,8 +672,7 @@ class PatternProviderNetworkNodeTest {
         sut.setPattern(1, PATTERN_A);
 
         // Act & assert
-        final Optional<TaskId> createdId =
-            autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+        final Optional<TaskId> createdId = autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE);
         assertThat(createdId).isPresent();
         assertThat(sut.getTasks()).isNotEmpty();
 
@@ -704,7 +703,7 @@ class PatternProviderNetworkNodeTest {
         sut.setSink((resources, action) -> ExternalPatternSink.Result.ACCEPTED);
 
         // Act & assert
-        assertThat(autocrafting.startTask(B, 2, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(autocrafting.startTask(B, 2, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         sut.doWork();
         taskShouldBeMarkedAsChangedOnce(listener);
@@ -828,7 +827,7 @@ class PatternProviderNetworkNodeTest {
             final PatternProviderExternalPatternSinkImpl sink2 = new PatternProviderExternalPatternSinkImpl();
             sut2.setSink(sink2);
 
-            assertThat(autocrafting.startTask(B, 3, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+            assertThat(autocrafting.startTask(B, 3, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
             assertThat(sut.getTasks()).hasSize(1);
             assertThat(sut2.getTasks()).isEmpty();
 
@@ -908,7 +907,7 @@ class PatternProviderNetworkNodeTest {
             final PatternProviderExternalPatternSinkImpl sink3 = new PatternProviderExternalPatternSinkImpl();
             sut3.setSink(sink3);
 
-            assertThat(autocrafting.startTask(B, 3, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+            assertThat(autocrafting.startTask(B, 3, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
             assertThat(sut.getTasks()).hasSize(1);
             assertThat(sut2.getTasks()).isEmpty();
             assertThat(sut3.getTasks()).isEmpty();
@@ -984,7 +983,7 @@ class PatternProviderNetworkNodeTest {
             sut2.setPattern(1, patternBuilder.build());
             sut2.setSink((resources, action) -> ExternalPatternSink.Result.REJECTED);
 
-            assertThat(autocrafting.startTask(B, 3, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+            assertThat(autocrafting.startTask(B, 3, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
             assertThat(sut.getTasks()).hasSize(1);
             assertThat(sut2.getTasks()).isEmpty();
 
@@ -1026,7 +1025,7 @@ class PatternProviderNetworkNodeTest {
             sut2.setPattern(1, patternBuilder.build());
             sut2.setSink((resources, action) -> ExternalPatternSink.Result.REJECTED);
 
-            assertThat(autocrafting.startTask(B, 3, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+            assertThat(autocrafting.startTask(B, 3, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
             assertThat(sut.getTasks()).hasSize(1);
             assertThat(sut2.getTasks()).isEmpty();
 
@@ -1093,7 +1092,7 @@ class PatternProviderNetworkNodeTest {
             final PatternProviderExternalPatternSinkImpl sink = new PatternProviderExternalPatternSinkImpl();
             sut.setSink(sink);
 
-            assertThat(autocrafting.startTask(B, 3, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+            assertThat(autocrafting.startTask(B, 3, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
             assertThat(sut.getTasks()).hasSize(1);
 
             // Act & assert
@@ -1162,7 +1161,7 @@ class PatternProviderNetworkNodeTest {
             sut.setSink((resources, action) -> ExternalPatternSink.Result.ACCEPTED);
 
             // Act & assert
-            assertThat(autocrafting.startTask(A, 3, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+            assertThat(autocrafting.startTask(A, 3, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
             sut.doWork();
             assertThat(sut.getTasks()).hasSize(1);
@@ -1285,7 +1284,7 @@ class PatternProviderNetworkNodeTest {
             sut.setPattern(1, PATTERN_A);
 
             // Act & assert
-            final var taskId = autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+            final var taskId = autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE);
             assertThat(taskId).isPresent();
             final ArgumentCaptor<TaskStatus> statusCaptor = ArgumentCaptor.forClass(TaskStatus.class);
             verify(listener, times(1)).taskAdded(statusCaptor.capture());
@@ -1325,7 +1324,7 @@ class PatternProviderNetworkNodeTest {
             sut.setPattern(1, PATTERN_A);
 
             // Act & assert
-            final var taskId = autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+            final var taskId = autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE);
             assertThat(taskId).isPresent();
             assertThat(sut.getTasks()).hasSize(1).allMatch(t -> t.getState() == TaskState.READY);
 
@@ -1367,7 +1366,7 @@ class PatternProviderNetworkNodeTest {
             other.setPattern(0, patternForB);
 
             // Act & assert
-            assertThat(autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+            assertThat(autocrafting.startTask(A, 1, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
             assertThat(sut.getTasks()).hasSize(1);
             assertThat(copyInternalStorage(sut.getTasks().getFirst())).isEmpty();
             assertThat(storage.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(

--- a/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/node/relay/RelayAutocraftingNetworkNodeTest.java
+++ b/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/node/relay/RelayAutocraftingNetworkNodeTest.java
@@ -373,9 +373,9 @@ class RelayAutocraftingNetworkNodeTest {
 
         // Act
         final var taskIdFromOutput =
-            outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+            outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE);
         final var taskIdFromInput =
-            inputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+            inputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE);
 
         // Assert
         assertThat(taskIdFromOutput).isPresent();
@@ -405,7 +405,7 @@ class RelayAutocraftingNetworkNodeTest {
         input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
 
         final var optionalTaskId =
-            outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+            outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE);
         assertThat(optionalTaskId).isPresent();
 
         // Act
@@ -438,7 +438,7 @@ class RelayAutocraftingNetworkNodeTest {
 
         // Act & assert
         final var optionalTaskId =
-            outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+            outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE);
         assertThat(optionalTaskId).isPresent();
         final var taskId = optionalTaskId.get();
         assertThat(output.getTasks())
@@ -478,7 +478,7 @@ class RelayAutocraftingNetworkNodeTest {
 
         input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
 
-        assertThat(outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         // Act & assert
         output.doWork();
@@ -514,7 +514,7 @@ class RelayAutocraftingNetworkNodeTest {
 
         input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
 
-        assertThat(outputAutocrafting.startTask(B, 10, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(outputAutocrafting.startTask(B, 10, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         // Act & assert
         output.doWork();
@@ -568,7 +568,7 @@ class RelayAutocraftingNetworkNodeTest {
 
         input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
 
-        assertThat(outputAutocrafting.startTask(B, 2, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+        assertThat(outputAutocrafting.startTask(B, 2, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
         // Act & assert
         output.doWork();
@@ -646,7 +646,7 @@ class RelayAutocraftingNetworkNodeTest {
             input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
 
             assertThat(
-                outputAutocrafting.startTask(B, 2, Actor.EMPTY, false, CancellationToken.NONE).join()).isPresent();
+                outputAutocrafting.startTask(B, 2, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
 
             // Act & assert
             output.doWork();
@@ -713,7 +713,7 @@ class RelayAutocraftingNetworkNodeTest {
             input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
 
             // Act & assert
-            final var taskId = outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+            final var taskId = outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE);
             assertThat(taskId).isPresent();
             final ArgumentCaptor<TaskStatus> statusCaptor = ArgumentCaptor.forClass(TaskStatus.class);
             verify(listener, times(1)).taskAdded(statusCaptor.capture());
@@ -768,7 +768,7 @@ class RelayAutocraftingNetworkNodeTest {
             input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING));
 
             // Act & assert
-            final var taskId = outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE).join();
+            final var taskId = outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE);
             assertThat(taskId).isPresent();
             assertThat(output.getTasks()).hasSize(1).allMatch(t -> t.getState() == TaskState.READY);
 

--- a/refinedstorage-resource-api/src/main/java/com/refinedmods/refinedstorage/api/resource/list/listenable/ListenableResourceList.java
+++ b/refinedstorage-resource-api/src/main/java/com/refinedmods/refinedstorage/api/resource/list/listenable/ListenableResourceList.java
@@ -9,6 +9,8 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 import org.apiguardian.api.API;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A resource list that can have listeners to track changes.
@@ -18,6 +20,7 @@ import org.apiguardian.api.API;
  */
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.1.2")
 public class ListenableResourceList extends AbstractProxyMutableResourceList {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ListenableResourceList.class);
     private final Set<ResourceListListener> listeners = new HashSet<>();
 
     public ListenableResourceList(final MutableResourceList delegate) {
@@ -42,14 +45,17 @@ public class ListenableResourceList extends AbstractProxyMutableResourceList {
     }
 
     private void notifyListeners(final OperationResult result) {
+        LOGGER.info("Notifying {} listeners of change: {}", listeners.size(), result);
         listeners.forEach(listener -> listener.changed(result));
     }
 
     public void addListener(final ResourceListListener listener) {
+        LOGGER.info("Adding listener: {}", listener);
         listeners.add(listener);
     }
 
     public void removeListener(final ResourceListListener listener) {
+        LOGGER.info("Removing listener: {}", listener);
         listeners.remove(listener);
     }
 }


### PR DESCRIPTION
The autocrafting task should be
added sync to the provider,
via the server thread,
just like everything else.

Starting the task sync
also has the benefit that the
storage cannot be modified
while this happens.

Fixes #1117