### PR TITLE
perf: skip missing resource calculation when unneeded

### DIFF
--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/CraftingCalculatorListener.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/CraftingCalculatorListener.java
@@ -25,4 +25,11 @@ public interface CraftingCalculatorListener<T> {
     }
 
     T getData();
+
+    /**
+     * {@return true if missing resource calculation must be complete}
+     */
+    default boolean requiresFullMissingResourcesCalculation() {
+        return true;
+    }
 }

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/CraftingTree.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/calculation/CraftingTree.java
@@ -77,6 +77,9 @@ class CraftingTree<T> {
                 cancellationToken);
             if (ingredientResult == CalculationResult.MISSING_RESOURCES) {
                 result = CalculationResult.MISSING_RESOURCES;
+                if (!listener.requiresFullMissingResourcesCalculation()) {
+                    break; // exit early, this subtree does not succeed
+                }
             }
         }
         craftingState.addOutputsToInternalStorage(pattern, amount);

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/craftability/IsCraftableCraftingCalculatorListener.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/craftability/IsCraftableCraftingCalculatorListener.java
@@ -98,4 +98,9 @@ public class IsCraftableCraftingCalculatorListener implements CraftingCalculator
     public Boolean getData() {
         return missingResources;
     }
+
+    @Override
+    public boolean requiresFullMissingResourcesCalculation() {
+        return false;
+    }
 }

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/TaskPlanCraftingCalculatorListener.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/task/TaskPlanCraftingCalculatorListener.java
@@ -70,4 +70,9 @@ public class TaskPlanCraftingCalculatorListener implements CraftingCalculatorLis
     public MutableTaskPlan getData() {
         return task;
     }
+
+    @Override
+    public boolean requiresFullMissingResourcesCalculation() {
+        return false;
+    }
 }

--- a/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/PatternTest.java
+++ b/refinedstorage-autocrafting-api/src/test/java/com/refinedmods/refinedstorage/api/autocrafting/PatternTest.java
@@ -24,23 +24,19 @@ class PatternTest {
     @Test
     void shouldCreateInternalPattern() {
         // Act
-        final Pattern sut = new Pattern(
-            UUID.randomUUID(),
-            new PatternLayout(
-                List.of(
-                    new Ingredient(1, List.of(A, B)),
-                    new Ingredient(2, List.of(C))
-                ),
-                List.of(
-                    new ResourceAmount(OAK_LOG, 3),
-                    new ResourceAmount(OAK_PLANKS, 4)
-                ),
-                List.of(
-                    new ResourceAmount(COBBLESTONE, 1)
-                ),
-                PatternType.INTERNAL
+        final Pattern sut = new Pattern(UUID.randomUUID(), PatternLayout.internal(
+            List.of(
+                new Ingredient(1, List.of(A, B)),
+                new Ingredient(2, List.of(C))
+            ),
+            List.of(
+                new ResourceAmount(OAK_LOG, 3),
+                new ResourceAmount(OAK_PLANKS, 4)
+            ),
+            List.of(
+                new ResourceAmount(COBBLESTONE, 1)
             )
-        );
+        ));
 
         // Assert
         assertThat(sut.layout().ingredients()).hasSize(2);
@@ -59,22 +55,49 @@ class PatternTest {
         assertThat(sut.layout().type()).isEqualTo(PatternType.INTERNAL);
     }
 
+    @Test
+    void shouldCreateExternalPattern() {
+        // Act
+        final Pattern sut = new Pattern(UUID.randomUUID(), PatternLayout.external(
+            List.of(
+                new Ingredient(1, List.of(A, B)),
+                new Ingredient(2, List.of(C))
+            ),
+            List.of(
+                new ResourceAmount(OAK_LOG, 3),
+                new ResourceAmount(OAK_PLANKS, 4)
+            )
+        ));
+
+        // Assert
+        assertThat(sut.layout().ingredients()).hasSize(2);
+        final Ingredient firstIngredient = sut.layout().ingredients().getFirst();
+        assertThat(firstIngredient.amount()).isEqualTo(1);
+        assertThat(firstIngredient.inputs()).containsExactly(A, B);
+        final Ingredient secondIngredient = sut.layout().ingredients().get(1);
+        assertThat(secondIngredient.amount()).isEqualTo(2);
+        assertThat(secondIngredient.inputs()).containsExactly(C);
+        assertThat(sut.layout().outputs()).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrder(
+            new ResourceAmount(OAK_LOG, 3),
+            new ResourceAmount(OAK_PLANKS, 4)
+        );
+        assertThat(sut.layout().byproducts()).isEmpty();
+        assertThat(sut.layout().type()).isEqualTo(PatternType.EXTERNAL);
+    }
+
     @ParameterizedTest
     @EnumSource(PatternType.class)
     void shouldNotCreatePatternWithoutIngredients(final PatternType type) {
         // Act
-        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
-            UUID.randomUUID(),
-            new PatternLayout(
-                List.of(),
-                List.of(
-                    new ResourceAmount(OAK_LOG, 3),
-                    new ResourceAmount(OAK_PLANKS, 4)
-                ),
-                List.of(),
-                type
-            )
-        );
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(UUID.randomUUID(), new PatternLayout(
+            List.of(),
+            List.of(
+                new ResourceAmount(OAK_LOG, 3),
+                new ResourceAmount(OAK_PLANKS, 4)
+            ),
+            List.of(),
+            type
+        ));
 
         // Assert
         assertThatThrownBy(action)
@@ -86,18 +109,15 @@ class PatternTest {
     @EnumSource(PatternType.class)
     void shouldNotCreatePatternWithoutOutputs(final PatternType type) {
         // Act
-        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
-            UUID.randomUUID(),
-            new PatternLayout(
-                List.of(
-                    new Ingredient(1, List.of(A, B)),
-                    new Ingredient(2, List.of(C))
-                ),
-                List.of(),
-                List.of(),
-                type
-            )
-        );
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(UUID.randomUUID(), new PatternLayout(
+            List.of(
+                new Ingredient(1, List.of(A, B)),
+                new Ingredient(2, List.of(C))
+            ),
+            List.of(),
+            List.of(),
+            type
+        ));
 
         // Assert
         assertThatThrownBy(action)
@@ -114,10 +134,7 @@ class PatternTest {
         outputs.add(new ResourceAmount(OAK_LOG, 3));
         final List<ResourceAmount> byproducts = new ArrayList<>();
         byproducts.add(new ResourceAmount(COBBLESTONE, 1));
-        final Pattern sut = new Pattern(
-            UUID.randomUUID(),
-            new PatternLayout(ingredients, outputs, byproducts, PatternType.INTERNAL)
-        );
+        final Pattern sut = new Pattern(UUID.randomUUID(), PatternLayout.internal(ingredients, outputs, byproducts));
 
         // Act
         ingredients.add(new Ingredient(2, List.of(C)));
@@ -133,15 +150,11 @@ class PatternTest {
     @Test
     void shouldNotBeAbleToModifyIngredientsAndOutputsAndByproducts() {
         // Arrange
-        final Pattern sut = new Pattern(
-            UUID.randomUUID(),
-            new PatternLayout(
-                List.of(new Ingredient(1, List.of(A))),
-                List.of(new ResourceAmount(OAK_LOG, 3)),
-                List.of(new ResourceAmount(OAK_PLANKS, 4)),
-                PatternType.INTERNAL
-            )
-        );
+        final Pattern sut = new Pattern(UUID.randomUUID(), PatternLayout.internal(
+            List.of(new Ingredient(1, List.of(A))),
+            List.of(new ResourceAmount(OAK_LOG, 3)),
+            List.of(new ResourceAmount(OAK_PLANKS, 4))
+        ));
         final List<Ingredient> ingredients = sut.layout().ingredients();
         final List<ResourceAmount> outputs = sut.layout().outputs();
         final List<ResourceAmount> byproducts = sut.layout().byproducts();
@@ -164,23 +177,20 @@ class PatternTest {
     @Test
     void shouldNotCreateExternalPatternWithByproducts() {
         // Act
-        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
-            UUID.randomUUID(),
-            new PatternLayout(
-                List.of(
-                    new Ingredient(1, List.of(A, B)),
-                    new Ingredient(2, List.of(C))
-                ),
-                List.of(
-                    new ResourceAmount(OAK_LOG, 3),
-                    new ResourceAmount(OAK_PLANKS, 4)
-                ),
-                List.of(
-                    new ResourceAmount(COBBLESTONE, 1)
-                ),
-                PatternType.EXTERNAL
-            )
-        );
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(UUID.randomUUID(), new PatternLayout(
+            List.of(
+                new Ingredient(1, List.of(A, B)),
+                new Ingredient(2, List.of(C))
+            ),
+            List.of(
+                new ResourceAmount(OAK_LOG, 3),
+                new ResourceAmount(OAK_PLANKS, 4)
+            ),
+            List.of(
+                new ResourceAmount(COBBLESTONE, 1)
+            ),
+            PatternType.EXTERNAL
+        ));
 
         // Assert
         assertThatThrownBy(action)
@@ -192,21 +202,18 @@ class PatternTest {
     @SuppressWarnings("ConstantConditions")
     void shouldNotCreatePatternWithNullType() {
         // Act
-        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
-            UUID.randomUUID(),
-            new PatternLayout(
-                List.of(
-                    new Ingredient(1, List.of(A, B)),
-                    new Ingredient(2, List.of(C))
-                ),
-                List.of(
-                    new ResourceAmount(OAK_LOG, 3),
-                    new ResourceAmount(OAK_PLANKS, 4)
-                ),
-                List.of(),
-                null
-            )
-        );
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(UUID.randomUUID(), new PatternLayout(
+            List.of(
+                new Ingredient(1, List.of(A, B)),
+                new Ingredient(2, List.of(C))
+            ),
+            List.of(
+                new ResourceAmount(OAK_LOG, 3),
+                new ResourceAmount(OAK_PLANKS, 4)
+            ),
+            List.of(),
+            null
+        ));
 
         // Assert
         assertThatThrownBy(action).isInstanceOf(NullPointerException.class);
@@ -217,18 +224,15 @@ class PatternTest {
     @SuppressWarnings("ConstantConditions")
     void shouldNotCreatePatternWithNullIngredients(final PatternType type) {
         // Act
-        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
-            UUID.randomUUID(),
-            new PatternLayout(
-                null,
-                List.of(
-                    new ResourceAmount(OAK_LOG, 3),
-                    new ResourceAmount(OAK_PLANKS, 4)
-                ),
-                List.of(),
-                type
-            )
-        );
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(UUID.randomUUID(), new PatternLayout(
+            null,
+            List.of(
+                new ResourceAmount(OAK_LOG, 3),
+                new ResourceAmount(OAK_PLANKS, 4)
+            ),
+            List.of(),
+            type
+        ));
 
         // Assert
         assertThatThrownBy(action).isInstanceOf(NullPointerException.class);
@@ -239,18 +243,15 @@ class PatternTest {
     @SuppressWarnings("ConstantConditions")
     void shouldNotCreatePatternWithNullOutputs(final PatternType type) {
         // Act
-        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
-            UUID.randomUUID(),
-            new PatternLayout(
-                List.of(
-                    new Ingredient(1, List.of(A, B)),
-                    new Ingredient(2, List.of(C))
-                ),
-                null,
-                List.of(),
-                type
-            )
-        );
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(UUID.randomUUID(), new PatternLayout(
+            List.of(
+                new Ingredient(1, List.of(A, B)),
+                new Ingredient(2, List.of(C))
+            ),
+            null,
+            List.of(),
+            type
+        ));
 
         // Assert
         assertThatThrownBy(action).isInstanceOf(NullPointerException.class);
@@ -260,21 +261,17 @@ class PatternTest {
     @SuppressWarnings("ConstantConditions")
     void shouldNotCreatePatternWithNullByproducts() {
         // Act
-        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
-            UUID.randomUUID(),
-            new PatternLayout(
-                List.of(
-                    new Ingredient(1, List.of(A, B)),
-                    new Ingredient(2, List.of(C))
-                ),
-                List.of(
-                    new ResourceAmount(OAK_LOG, 3),
-                    new ResourceAmount(OAK_PLANKS, 4)
-                ),
-                null,
-                PatternType.INTERNAL
-            )
-        );
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(UUID.randomUUID(), PatternLayout.internal(
+            List.of(
+                new Ingredient(1, List.of(A, B)),
+                new Ingredient(2, List.of(C))
+            ),
+            List.of(
+                new ResourceAmount(OAK_LOG, 3),
+                new ResourceAmount(OAK_PLANKS, 4)
+            ),
+            null
+        ));
 
         // Assert
         assertThatThrownBy(action).isInstanceOf(NullPointerException.class);
@@ -284,21 +281,17 @@ class PatternTest {
     @SuppressWarnings("ConstantConditions")
     void shouldNotCreateWithNullId() {
         // Act
-        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(
-            null,
-            new PatternLayout(
-                List.of(
-                    new Ingredient(1, List.of(A, B)),
-                    new Ingredient(2, List.of(C))
-                ),
-                List.of(
-                    new ResourceAmount(OAK_LOG, 3),
-                    new ResourceAmount(OAK_PLANKS, 4)
-                ),
-                List.of(),
-                PatternType.INTERNAL
-            )
-        );
+        final ThrowableAssert.ThrowingCallable action = () -> new Pattern(null, PatternLayout.internal(
+            List.of(
+                new Ingredient(1, List.of(A, B)),
+                new Ingredient(2, List.of(C))
+            ),
+            List.of(
+                new ResourceAmount(OAK_LOG, 3),
+                new ResourceAmount(OAK_PLANKS, 4)
+            ),
+            List.of()
+        ));
 
         // Assert
         assertThatThrownBy(action).isInstanceOf(NullPointerException.class);


### PR DESCRIPTION
As written in #987, we can take a shortcut if we don't need a complete list of missing resources. 