### PR TITLE
perf: check for network receiver before rebuilding network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 -  The storage network losing track of resources that can be autocrafted.
+-   Reduced lag spikes when Network Receivers are missing.
 
 ## [2.0.0-beta.13] - 2025-09-13
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/NetworkTransmitterBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/NetworkTransmitterBlockEntity.java
@@ -27,11 +27,13 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.network.codec.StreamEncoder;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -160,7 +162,25 @@ public class NetworkTransmitterBlockEntity
             receiverKey,
             worldPosition
         );
-        containers.update(level);
+        if (isReceiverFoundInLevel()) {
+            containers.update(level);
+        }
+    }
+
+    private boolean isReceiverFoundInLevel() {
+        if (level == null || receiverKey == null) {
+            return false;
+        }
+        final MinecraftServer server = level.getServer();
+        if (server == null) {
+            return false;
+        }
+        final Level level = server.getLevel(receiverKey.pos().dimension());
+        if (level == null || !level.isLoaded(receiverKey.pos().pos())) {
+            return false;
+        }
+        final BlockState blockState = level.getBlockState(receiverKey.pos().pos());
+        return blockState.getBlock() instanceof NetworkReceiverBlock;
     }
 
     private static boolean isReceiverFoundInNetwork(final Network network, final NetworkReceiverKey key) {

--- a/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/autocrafting/AutocraftingNetworkComponentImpl.java
+++ b/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/autocrafting/AutocraftingNetworkComponentImpl.java
@@ -18,7 +18,6 @@ import com.refinedmods.refinedstorage.api.autocrafting.task.TaskId;
 import com.refinedmods.refinedstorage.api.autocrafting.task.TaskImpl;
 import com.refinedmods.refinedstorage.api.autocrafting.task.TaskPlan;
 import com.refinedmods.refinedstorage.api.core.CoreValidations;
-import com.refinedmods.refinedstorage.api.network.Network;
 import com.refinedmods.refinedstorage.api.network.autocrafting.AutocraftingNetworkComponent;
 import com.refinedmods.refinedstorage.api.network.autocrafting.ParentContainer;
 import com.refinedmods.refinedstorage.api.network.autocrafting.PatternListener;


### PR DESCRIPTION
Only rebuild the network if a receiver is at the target location