### PR TITLE
Expose upgrade/pattern slots to external devices (hoppers, etc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Hoppers can insert upgrades, patterns, and security cards into devices which support them.
+
 ## [2.0.0] - 2025-09-27
 
 ### Fixed

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/autocrafter/AutocrafterBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/autocrafting/autocrafter/AutocrafterBlockEntity.java
@@ -135,11 +135,11 @@ public class AutocrafterBlockEntity extends AbstractBaseNetworkNodeContainerBloc
         );
     }
 
-    FilteredContainer getPatternContainer() {
+    public FilteredContainer getPatternContainer() {
         return patternContainer;
     }
 
-    UpgradeContainer getUpgradeContainer() {
+    public UpgradeContainer getUpgradeContainer() {
         return upgradeContainer;
     }
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/constructordestructor/AbstractConstructorBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/constructordestructor/AbstractConstructorBlockEntity.java
@@ -36,6 +36,7 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamEncoder;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -83,6 +84,10 @@ public abstract class AbstractConstructorBlockEntity
 
     void setFilters(final List<ResourceKey> filters) {
         mainNetworkNode.setFilters(filters);
+    }
+
+    public Container getUpgradeContainer() {
+        return upgradeContainer;
     }
 
     @Override

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/constructordestructor/AbstractDestructorBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/constructordestructor/AbstractDestructorBlockEntity.java
@@ -32,6 +32,7 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamEncoder;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -71,6 +72,10 @@ public abstract class AbstractDestructorBlockEntity
             }
         }, ConstructorDestructorConstants.DEFAULT_WORK_TICK_RATE);
         this.ticker = upgradeContainer.getTicker();
+    }
+
+    public Container getUpgradeContainer() {
+        return upgradeContainer;
     }
 
     @Override

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/exporter/AbstractExporterBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/exporter/AbstractExporterBlockEntity.java
@@ -39,6 +39,7 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamEncoder;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -84,6 +85,10 @@ public abstract class AbstractExporterBlockEntity
     private void schedulingModeChanged(final SchedulingMode schedulingMode) {
         mainNetworkNode.setSchedulingMode(schedulingMode);
         setChanged();
+    }
+
+    public Container getUpgradeContainer() {
+        return upgradeContainer;
     }
 
     @Override

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/importer/AbstractImporterBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/importer/AbstractImporterBlockEntity.java
@@ -78,6 +78,10 @@ public abstract class AbstractImporterBlockEntity
         this.ticker = upgradeContainer.getTicker();
     }
 
+    public Container getUpgradeContainer() {
+        return upgradeContainer;
+    }
+
     @Override
     public List<ItemStack> getUpgrades() {
         return upgradeContainer.getUpgrades();

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/NetworkTransmitterBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/NetworkTransmitterBlockEntity.java
@@ -187,7 +187,7 @@ public class NetworkTransmitterBlockEntity
         return network.getComponent(GraphNetworkComponent.class).getContainer(key) != null;
     }
 
-    Container getNetworkCardInventory() {
+    public Container getNetworkCardInventory() {
         return networkCardInventory;
     }
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/WirelessTransmitterBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/networking/WirelessTransmitterBlockEntity.java
@@ -24,6 +24,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.codec.StreamEncoder;
+import net.minecraft.world.Container;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
@@ -71,6 +72,10 @@ public class WirelessTransmitterBlockEntity
             ContainerUtil.read(tag.getCompound(TAG_UPGRADES), upgradeContainer, provider);
         }
         super.loadAdditional(tag, provider);
+    }
+
+    public Container getUpgradeContainer() {
+        return upgradeContainer;
     }
 
     @Override

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/security/SecurityManagerBlockEntity.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/security/SecurityManagerBlockEntity.java
@@ -143,11 +143,11 @@ public class SecurityManagerBlockEntity
         return drops;
     }
 
-    FilteredContainer getSecurityCards() {
+    public FilteredContainer getSecurityCards() {
         return securityCards;
     }
 
-    FilteredContainer getFallbackSecurityCard() {
+    public FilteredContainer getFallbackSecurityCard() {
         return fallbackSecurityCard;
     }
 

--- a/refinedstorage-fabric/src/main/java/com/refinedmods/refinedstorage/fabric/ModInitializerImpl.java
+++ b/refinedstorage-fabric/src/main/java/com/refinedmods/refinedstorage/fabric/ModInitializerImpl.java
@@ -6,6 +6,8 @@ import com.refinedmods.refinedstorage.common.api.RefinedStorageApi;
 import com.refinedmods.refinedstorage.common.api.support.network.AbstractNetworkNodeContainerBlockEntity;
 import com.refinedmods.refinedstorage.common.autocrafting.monitor.WirelessAutocraftingMonitorItem;
 import com.refinedmods.refinedstorage.common.autocrafting.patterngrid.PatternGridBlockEntity;
+import com.refinedmods.refinedstorage.common.constructordestructor.AbstractConstructorBlockEntity;
+import com.refinedmods.refinedstorage.common.constructordestructor.AbstractDestructorBlockEntity;
 import com.refinedmods.refinedstorage.common.content.BlockEntities;
 import com.refinedmods.refinedstorage.common.content.BlockEntityProvider;
 import com.refinedmods.refinedstorage.common.content.BlockEntityProviders;
@@ -18,8 +20,12 @@ import com.refinedmods.refinedstorage.common.content.ExtendedMenuTypeFactory;
 import com.refinedmods.refinedstorage.common.content.Items;
 import com.refinedmods.refinedstorage.common.content.MenuTypeFactory;
 import com.refinedmods.refinedstorage.common.content.RegistryCallback;
+import com.refinedmods.refinedstorage.common.exporter.AbstractExporterBlockEntity;
 import com.refinedmods.refinedstorage.common.grid.WirelessGridItem;
 import com.refinedmods.refinedstorage.common.iface.InterfaceBlockEntity;
+import com.refinedmods.refinedstorage.common.importer.AbstractImporterBlockEntity;
+import com.refinedmods.refinedstorage.common.networking.NetworkTransmitterBlockEntity;
+import com.refinedmods.refinedstorage.common.networking.WirelessTransmitterBlockEntity;
 import com.refinedmods.refinedstorage.common.security.FallbackSecurityCardItem;
 import com.refinedmods.refinedstorage.common.security.SecurityCardItem;
 import com.refinedmods.refinedstorage.common.storage.FluidStorageVariant;
@@ -873,6 +879,42 @@ public class ModInitializerImpl extends AbstractModInitializer implements ModIni
             PatternGridBlockEntity::getPatternInput,
             BlockEntities.INSTANCE.getPatternGrid()
         );
+        registerItemStorage(
+            AbstractImporterBlockEntity.class::isInstance,
+            AbstractImporterBlockEntity.class::cast,
+            AbstractImporterBlockEntity::getUpgradeContainer,
+            BlockEntities.INSTANCE.getImporter()
+        );
+        registerItemStorage(
+            AbstractExporterBlockEntity.class::isInstance,
+            AbstractExporterBlockEntity.class::cast,
+            AbstractExporterBlockEntity::getUpgradeContainer,
+            BlockEntities.INSTANCE.getExporter()
+        );
+        registerItemStorage(
+            AbstractConstructorBlockEntity.class::isInstance,
+            AbstractConstructorBlockEntity.class::cast,
+            AbstractConstructorBlockEntity::getUpgradeContainer,
+            BlockEntities.INSTANCE.getConstructor()
+        );
+        registerItemStorage(
+            AbstractDestructorBlockEntity.class::isInstance,
+            AbstractDestructorBlockEntity.class::cast,
+            AbstractDestructorBlockEntity::getUpgradeContainer,
+            BlockEntities.INSTANCE.getDestructor()
+        );
+        registerItemStorage(
+            WirelessTransmitterBlockEntity.class::isInstance,
+            WirelessTransmitterBlockEntity.class::cast,
+            WirelessTransmitterBlockEntity::getUpgradeContainer,
+            BlockEntities.INSTANCE.getWirelessTransmitter()
+        );
+        registerItemStorage(
+            NetworkTransmitterBlockEntity.class::isInstance,
+            NetworkTransmitterBlockEntity.class::cast,
+            NetworkTransmitterBlockEntity::getNetworkCardInventory,
+            BlockEntities.INSTANCE.getNetworkTransmitter()
+        );
         ItemStorage.SIDED.registerForBlockEntity((blockEntity, context) -> {
             final InventoryStorage storage = InventoryStorage.of(blockEntity.getDiskInventory(), context);
             final List<Storage<ItemVariant>> parts = new ArrayList<>();
@@ -882,6 +924,29 @@ public class ModInitializerImpl extends AbstractModInitializer implements ModIni
             }
             return new CombinedStorage<>(parts);
         }, BlockEntities.INSTANCE.getDiskInterface());
+        ItemStorage.SIDED.registerForBlockEntity((autocrafter, context) -> {
+            final InventoryStorage patternStorage = InventoryStorage.of(autocrafter.getPatternContainer(), context);
+            final InventoryStorage upgradeStorage = InventoryStorage.of(autocrafter.getUpgradeContainer(), context);
+            final List<Storage<ItemVariant>> parts = new ArrayList<>();
+
+            parts.add(patternStorage);
+            parts.add(upgradeStorage);
+
+            return new CombinedStorage<>(parts);
+        }, BlockEntities.INSTANCE.getAutocrafter());
+        ItemStorage.SIDED.registerForBlockEntity((securityManager, context) -> {
+            final InventoryStorage securityCards = InventoryStorage.of(securityManager.getSecurityCards(), context);
+            final InventoryStorage fallbackCard =
+                InventoryStorage.of(securityManager.getFallbackSecurityCard(), context);
+            final List<Storage<ItemVariant>> parts = new ArrayList<>();
+
+            parts.add(securityCards);
+            parts.add(fallbackCard);
+
+            return new CombinedStorage<>(parts);
+        }, BlockEntities.INSTANCE.getSecurityManager());
+
+
         FluidStorage.SIDED.registerForBlockEntity(
             (blockEntity, context) -> new ResourceContainerFluidStorageAdapter(blockEntity.getExportedResources()),
             BlockEntities.INSTANCE.getInterface()

--- a/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/ModInitializer.java
+++ b/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/ModInitializer.java
@@ -554,14 +554,14 @@ public class ModInitializer extends AbstractModInitializer {
         );
         event.registerBlockEntity(
             Capabilities.ItemHandler.BLOCK,
-            BlockEntities.INSTANCE.getSecurityManager(),
-            (be, side) -> new CombinedInvWrapper(new InvWrapper(be.getSecurityCards()),
-                new InvWrapper(be.getFallbackSecurityCard()))
+            BlockEntities.INSTANCE.getNetworkTransmitter(),
+            (be, side) -> new InvWrapper(be.getNetworkCardInventory())
         );
         event.registerBlockEntity(
             Capabilities.ItemHandler.BLOCK,
-            BlockEntities.INSTANCE.getNetworkTransmitter(),
-            (be, side) -> new InvWrapper(be.getNetworkCardInventory())
+            BlockEntities.INSTANCE.getSecurityManager(),
+            (be, side) -> new CombinedInvWrapper(new InvWrapper(be.getSecurityCards()),
+                new InvWrapper(be.getFallbackSecurityCard()))
         );
         event.registerBlockEntity(
             Capabilities.FluidHandler.BLOCK,

--- a/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/ModInitializer.java
+++ b/refinedstorage-neoforge/src/main/java/com/refinedmods/refinedstorage/neoforge/ModInitializer.java
@@ -165,6 +165,7 @@ import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.event.server.ServerStartingEvent;
 import net.neoforged.neoforge.event.server.ServerStoppedEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
+import net.neoforged.neoforge.items.wrapper.CombinedInvWrapper;
 import net.neoforged.neoforge.items.wrapper.InvWrapper;
 import net.neoforged.neoforge.items.wrapper.RangedWrapper;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
@@ -519,6 +520,48 @@ public class ModInitializer extends AbstractModInitializer {
             Capabilities.ItemHandler.BLOCK,
             BlockEntities.INSTANCE.getPatternGrid(),
             (be, side) -> new InvWrapper(be.getPatternInput())
+        );
+        event.registerBlockEntity(
+            Capabilities.ItemHandler.BLOCK,
+            BlockEntities.INSTANCE.getAutocrafter(),
+            (be, side) -> new CombinedInvWrapper(new InvWrapper(be.getPatternContainer()),
+                new InvWrapper(be.getUpgradeContainer()))
+        );
+        event.registerBlockEntity(
+            Capabilities.ItemHandler.BLOCK,
+            BlockEntities.INSTANCE.getImporter(),
+            (be, side) -> new InvWrapper(be.getUpgradeContainer())
+        );
+        event.registerBlockEntity(
+            Capabilities.ItemHandler.BLOCK,
+            BlockEntities.INSTANCE.getExporter(),
+            (be, side) -> new InvWrapper(be.getUpgradeContainer())
+        );
+        event.registerBlockEntity(
+            Capabilities.ItemHandler.BLOCK,
+            BlockEntities.INSTANCE.getConstructor(),
+            (be, side) -> new InvWrapper(be.getUpgradeContainer())
+        );
+        event.registerBlockEntity(
+            Capabilities.ItemHandler.BLOCK,
+            BlockEntities.INSTANCE.getDestructor(),
+            (be, side) -> new InvWrapper(be.getUpgradeContainer())
+        );
+        event.registerBlockEntity(
+            Capabilities.ItemHandler.BLOCK,
+            BlockEntities.INSTANCE.getWirelessTransmitter(),
+            (be, side) -> new InvWrapper(be.getUpgradeContainer())
+        );
+        event.registerBlockEntity(
+            Capabilities.ItemHandler.BLOCK,
+            BlockEntities.INSTANCE.getSecurityManager(),
+            (be, side) -> new CombinedInvWrapper(new InvWrapper(be.getSecurityCards()),
+                new InvWrapper(be.getFallbackSecurityCard()))
+        );
+        event.registerBlockEntity(
+            Capabilities.ItemHandler.BLOCK,
+            BlockEntities.INSTANCE.getNetworkTransmitter(),
+            (be, side) -> new InvWrapper(be.getNetworkCardInventory())
         );
         event.registerBlockEntity(
             Capabilities.FluidHandler.BLOCK,


### PR DESCRIPTION
This commit allows hoppers to insert/extract upgrades from the following devices:

- **Autocrafter**: patterns, upgrades
- **Importer**: upgrades
- **Exporter**: upgrades
- **Constructor**: upgrades
- **Destructor**: upgrades
- **Wireless Transmitter**: upgrades
- **Network Transmitter**: upgrades
- **Security Manager**: security cards, fallback security card

