### PR TITLE
perf: lazily compute PreviewBuilder state

### DIFF
--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/preview/PreviewBuilder.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/preview/PreviewBuilder.java
@@ -5,22 +5,30 @@ import com.refinedmods.refinedstorage.api.core.CoreValidations;
 import com.refinedmods.refinedstorage.api.resource.ResourceAmount;
 import com.refinedmods.refinedstorage.api.resource.ResourceKey;
 
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 public class PreviewBuilder {
     private final Map<ResourceKey, MutablePreviewItem> items;
     private List<ResourceAmount> outputsOfPatternWithCycle = Collections.emptyList();
     private boolean missing;
+    private final @Nullable PreviewBuilder parent;
 
     private PreviewBuilder() {
         items = new LinkedHashMap<>();
+        parent = null;
     }
 
-    private PreviewBuilder(final int size) {
-        items = LinkedHashMap.newLinkedHashMap(size);
+    private PreviewBuilder(final PreviewBuilder parent) {
+        items = new LinkedHashMap<>();
+        this.parent = parent;
+        missing = parent.missing;
+        outputsOfPatternWithCycle = parent.outputsOfPatternWithCycle;
     }
 
     public static PreviewBuilder create() {
@@ -56,18 +64,25 @@ public class PreviewBuilder {
     }
 
     public PreviewBuilder copy() {
-        final PreviewBuilder copy = new PreviewBuilder(items.size());
-        for (final Map.Entry<ResourceKey, MutablePreviewItem> entry : items.entrySet()) {
-            final MutablePreviewItem item = entry.getValue();
-            copy.items.put(entry.getKey(), item.copy());
-        }
-        copy.outputsOfPatternWithCycle = outputsOfPatternWithCycle;
-        copy.missing = missing;
-        return copy;
+        return new PreviewBuilder(this);
     }
 
     public Preview build() {
-        return new Preview(getType(), items.entrySet()
+        PreviewBuilder builder = this;
+        // collect a trace until the root (excluded)
+        final ArrayDeque<PreviewBuilder> path = new ArrayDeque<>();
+        while (builder.parent != null) {
+            path.addFirst(builder);
+            builder = builder.parent;
+        }
+        // walk from the root downwards to ensure proper ordering of the items
+        final PreviewBuilder root = builder;
+        for (final PreviewBuilder previewBuilder : path) {
+            for (final Map.Entry<ResourceKey, MutablePreviewItem> entry : previewBuilder.items.entrySet()) {
+                root.items.merge(entry.getKey(), entry.getValue().copy(), MutablePreviewItem::merge);
+            }
+        }
+        return new Preview(getType(), root.items.entrySet()
             .stream()
             .map(entry -> entry.getValue().toPreviewItem(entry.getKey()))
             .toList(), outputsOfPatternWithCycle);
@@ -95,6 +110,13 @@ public class PreviewBuilder {
             copy.missing = missing;
             copy.toCraft = toCraft;
             return copy;
+        }
+
+        private MutablePreviewItem merge(final MutablePreviewItem mutablePreviewItem) {
+            available += mutablePreviewItem.available;
+            missing += mutablePreviewItem.missing;
+            toCraft += mutablePreviewItem.toCraft;
+            return this;
         }
     }
 }


### PR DESCRIPTION
Trying to re-use TreePreviewCraftingCalculatorListener to calculate the normal Preview too, as that seems to have better performance characteristics.