### PR TITLE
perf: faster hashCode implementations for ItemResource and Pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved performance in various scenarios like autocrafting and opening a Grid. 
+
 ## [2.0.0] - 2025-09-27
 
 ### Fixed

--- a/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/Pattern.java
+++ b/refinedstorage-autocrafting-api/src/main/java/com/refinedmods/refinedstorage/api/autocrafting/Pattern.java
@@ -18,4 +18,16 @@ public record Pattern(UUID id, PatternLayout layout) {
         CoreValidations.validateNotNull(id, "ID cannot be null");
         CoreValidations.validateNotNull(layout, "Layout cannot be null");
     }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return obj instanceof Pattern(UUID uuid, PatternLayout patternLayout)
+                && uuid.equals(id)
+                && patternLayout.equals(layout);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
 }

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/resource/FluidResource.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/resource/FluidResource.java
@@ -9,6 +9,7 @@ import com.refinedmods.refinedstorage.common.api.support.resource.ResourceTag;
 import com.refinedmods.refinedstorage.common.api.support.resource.ResourceType;
 
 import java.util.List;
+import java.util.Objects;
 
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -16,8 +17,12 @@ import net.minecraft.world.level.material.Fluid;
 import org.apiguardian.api.API;
 
 @API(status = API.Status.INTERNAL)
-public record FluidResource(Fluid fluid, DataComponentPatch components)
+public final class FluidResource
     implements PlatformResourceKey, FuzzyModeNormalizer {
+    private final Fluid fluid;
+    private final DataComponentPatch components;
+    private int hash = 0;
+
     public FluidResource(final Fluid fluid) {
         this(fluid, DataComponentPatch.EMPTY);
     }
@@ -57,4 +62,39 @@ public record FluidResource(Fluid fluid, DataComponentPatch components)
     public ResourceType getResourceType() {
         return ResourceTypes.FLUID;
     }
+
+    public Fluid fluid() {
+        return fluid;
+    }
+
+    public DataComponentPatch components() {
+        return components;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof FluidResource that)) {
+            return false;
+        }
+        return fluid.equals(that.fluid) && components.equals(that.components);
+    }
+
+    @Override
+    public int hashCode() {
+        if (hash == 0) {
+            hash = Objects.hash(fluid, components);
+        }
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return "FluidResource["
+            + "fluid=" + fluid + ", "
+            + "components=" + components + ']';
+    }
+
 }

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/resource/ItemResource.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/resource/ItemResource.java
@@ -8,6 +8,7 @@ import com.refinedmods.refinedstorage.common.api.support.resource.ResourceTag;
 import com.refinedmods.refinedstorage.common.api.support.resource.ResourceType;
 
 import java.util.List;
+import java.util.Objects;
 
 import net.minecraft.core.component.DataComponentPatch;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -18,9 +19,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @API(status = API.Status.INTERNAL)
-public record ItemResource(Item item, DataComponentPatch components)
+public final class ItemResource
     implements PlatformResourceKey, FuzzyModeNormalizer {
     private static final Logger LOGGER = LoggerFactory.getLogger(ItemResource.class);
+    private final Item item;
+    private final DataComponentPatch components;
+    private int hash = 0;
 
     public ItemResource(final Item item) {
         this(item, DataComponentPatch.EMPTY);
@@ -76,4 +80,39 @@ public record ItemResource(Item item, DataComponentPatch components)
     public static ItemResource ofItemStack(final ItemStack itemStack) {
         return new ItemResource(itemStack.getItem(), itemStack.getComponentsPatch());
     }
+
+    public Item item() {
+        return item;
+    }
+
+    public DataComponentPatch components() {
+        return components;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (!(obj instanceof ItemResource that)) {
+            return false;
+        }
+        return this.item.equals(that.item) && this.components.equals(that.components);
+    }
+
+    @Override
+    public int hashCode() {
+        if (hash == 0) {
+            hash = Objects.hash(item, components);
+        }
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return "ItemResource["
+                + "item=" + item + ", "
+                + "components=" + components + ']';
+    }
+
 }


### PR DESCRIPTION
This still seems to be a significant contributor wherever HashMaps/HashSets are used.
The `equals` method in the record is needed to make checkstyle happy.