### PR TITLE
feat: support underscores and forward slashes in identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -   Improved performance in various scenarios like autocrafting and opening a Grid. 
 -   Fixed autocrafter name field history not working
+-   Added support for underscores and forward slashes in search names.
 
 ## [2.0.0] - 2025-09-27
 

--- a/refinedstorage-query-parser/src/main/java/com/refinedmods/refinedstorage/query/lexer/Lexer.java
+++ b/refinedstorage-query-parser/src/main/java/com/refinedmods/refinedstorage/query/lexer/Lexer.java
@@ -46,7 +46,7 @@ public class Lexer {
     }
 
     private boolean isValidIdentifier(final char c) {
-        return Character.isLetterOrDigit(c);
+        return c == '_' || c == '/' || Character.isLetterOrDigit(c);
     }
 
     private void scanNumber() {

--- a/refinedstorage-query-parser/src/test/java/com/refinedmods/refinedstorage/query/lexer/LexerTest.java
+++ b/refinedstorage-query-parser/src/test/java/com/refinedmods/refinedstorage/query/lexer/LexerTest.java
@@ -69,6 +69,83 @@ class LexerTest {
     }
 
     @Test
+    void testUnderscoreInIdentifier() {
+        // Act
+        final List<Token> tokens = getTokens("foo_bar");
+
+        // Assert
+        assertThat(tokens).hasSize(1);
+
+        final Token token = tokens.getFirst();
+        assertToken(token, "foo_bar", TokenType.IDENTIFIER);
+        assertPosition(token.position(), SOURCE_NAME, 1, 1, 1, 7);
+    }
+
+    @Test
+    void testSlashInIdentifier() {
+        // Act
+        final List<Token> tokens = getTokens("foo/bar");
+
+        // Assert
+        assertThat(tokens).hasSize(1);
+
+        final Token token = tokens.getFirst();
+        assertToken(token, "foo/bar", TokenType.IDENTIFIER);
+        assertPosition(token.position(), SOURCE_NAME, 1, 1, 1, 7);
+    }
+
+    @Test
+    void testUnderscoreAndSlashInIdentifier() {
+        // Act
+        final List<Token> tokens = getTokens("foo/bar_baz");
+
+        // Assert
+        assertThat(tokens).hasSize(1);
+
+        final Token token = tokens.getFirst();
+        assertToken(token, "foo/bar_baz", TokenType.IDENTIFIER);
+        assertPosition(token.position(), SOURCE_NAME, 1, 1, 1, 11);
+    }
+
+    @Test
+    void testMultipleUnderscoreAndSlashInIdentifier() {
+        // Act
+        final List<Token> tokens = getTokens("foo_bar/ba__z/quux_1/e2//d");
+
+        // Assert
+        assertThat(tokens).hasSize(1);
+
+        final Token token = tokens.getFirst();
+        assertToken(token, "foo_bar/ba__z/quux_1/e2//d", TokenType.IDENTIFIER);
+        assertPosition(token.position(), SOURCE_NAME, 1, 1, 1, 26);
+    }
+
+    @Test
+    void testSlashOperatorWithSlashInIdentifier() {
+        // Act
+        final List<Token> tokens = getTokens("/ foo/ /bar");
+
+        // Assert
+        assertThat(tokens).hasSize(4);
+
+        final Token slash = tokens.getFirst();
+        assertToken(slash, "/", TokenType.BIN_OP);
+        assertPosition(slash.position(), SOURCE_NAME, 1, 1, 1, 1);
+
+        final Token foo = tokens.get(1);
+        assertToken(foo, "foo/", TokenType.IDENTIFIER);
+        assertPosition(foo.position(), SOURCE_NAME, 1, 3, 1, 6);
+
+        final Token slash2 = tokens.get(2);
+        assertToken(slash2, "/", TokenType.BIN_OP);
+        assertPosition(slash2.position(), SOURCE_NAME, 1, 8, 1, 8);
+
+        final Token bar = tokens.get(3);
+        assertToken(bar, "bar", TokenType.IDENTIFIER);
+        assertPosition(bar.position(), SOURCE_NAME, 1, 9, 1, 11);
+    }
+
+    @Test
     void testSingleStringIdentifier() {
         // Act
         final List<Token> tokens = getTokens("\"h_el1lo\"");

--- a/refinedstorage-query-parser/src/test/java/com/refinedmods/refinedstorage/query/lexer/SyntaxHighlighterTest.java
+++ b/refinedstorage-query-parser/src/test/java/com/refinedmods/refinedstorage/query/lexer/SyntaxHighlighterTest.java
@@ -47,6 +47,16 @@ class SyntaxHighlighterTest {
                 )
             ),
             Arguments.of(
+                "a_b/c",
+                Arrays.asList(
+                    new SyntaxHighlightedCharacter("a", "WHITE"),
+                    new SyntaxHighlightedCharacter("_", "WHITE"),
+                    new SyntaxHighlightedCharacter("b", "WHITE"),
+                    new SyntaxHighlightedCharacter("/", "WHITE"),
+                    new SyntaxHighlightedCharacter("c", "WHITE")
+                )
+            ),
+            Arguments.of(
                 "!not&&",
                 Arrays.asList(
                     new SyntaxHighlightedCharacter("!", "AQUA"),


### PR DESCRIPTION
This will allow users to search for more complex item and/or block tags, such as `#wooden_pressure_plates` or `#mineable/axe`.