### PR TITLE
fix: Containermenu slot lists do not get cleared

### DIFF
--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/mixin/ContainerMenuAccessor.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/mixin/ContainerMenuAccessor.java
@@ -1,0 +1,16 @@
+package com.refinedmods.refinedstorage.common.mixin;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(AbstractContainerMenu.class)
+public interface ContainerMenuAccessor {
+    @Accessor("remoteSlots")
+    NonNullList<ItemStack> getRemoteSlots();
+
+    @Accessor("lastSlots")
+    NonNullList<ItemStack> getLastSlots();
+}

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/mixin/package-info.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/mixin/package-info.java
@@ -1,0 +1,7 @@
+@ParametersAreNonnullByDefault
+@FieldsAndMethodsAreNonnullByDefault
+package com.refinedmods.refinedstorage.common.mixin;
+
+import com.refinedmods.refinedstorage.api.core.FieldsAndMethodsAreNonnullByDefault;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/AbstractBaseContainerMenu.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/support/AbstractBaseContainerMenu.java
@@ -2,6 +2,7 @@ package com.refinedmods.refinedstorage.common.support;
 
 import com.refinedmods.refinedstorage.common.Platform;
 import com.refinedmods.refinedstorage.common.api.support.slotreference.SlotReference;
+import com.refinedmods.refinedstorage.common.mixin.ContainerMenuAccessor;
 import com.refinedmods.refinedstorage.common.support.containermenu.ClientProperty;
 import com.refinedmods.refinedstorage.common.support.containermenu.DisabledSlot;
 import com.refinedmods.refinedstorage.common.support.containermenu.FilterSlot;
@@ -63,6 +64,8 @@ public abstract class AbstractBaseContainerMenu extends AbstractContainerMenu {
 
     protected void resetSlots() {
         slots.clear();
+        ((ContainerMenuAccessor) this).getRemoteSlots().clear();
+        ((ContainerMenuAccessor) this).getLastSlots().clear();
     }
 
     protected final void addPlayerInventory(final Inventory inventory,

--- a/refinedstorage-common/src/main/resources/refinedstorage.common.mixins.json
+++ b/refinedstorage-common/src/main/resources/refinedstorage.common.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "com.refinedmods.refinedstorage.common.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "mixins": [
+    "ContainerMenuAccessor"
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}

--- a/refinedstorage-fabric/src/main/resources/fabric.mod.json
+++ b/refinedstorage-fabric/src/main/resources/fabric.mod.json
@@ -34,7 +34,8 @@
     }
   },
   "mixins": [
-    "refinedstorage.mixins.json"
+    "refinedstorage.mixins.json",
+    "refinedstorage.common.mixins.json"
   ],
   "depends": {
     "fabricloader": ">=0.14.6",

--- a/refinedstorage-neoforge/src/main/templates/META-INF/neoforge.mods.toml
+++ b/refinedstorage-neoforge/src/main/templates/META-INF/neoforge.mods.toml
@@ -14,6 +14,8 @@ Refined Storage is a mass storage mod for Minecraft that offers the player a net
 '''
 [[mixins]]
 config="refinedstorage.mixins.json"
+[[mixins]]
+config="refinedstorage.common.mixins.json"
 [[dependencies.refinedstorage]]
 modId = "neoforge"
 type = "required"


### PR DESCRIPTION
fixes #1240

A similar fix might be needed for dataSlots and remoteDataSlots but I didn't look into those.