### PR TITLE
fix: correct the torch model for detectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+-   Correct the torch model for detectors.
+
 ## [2.0.1] - 2026-02-11
 
 ### Added

--- a/refinedstorage-common/src/main/resources/assets/refinedstorage/models/block/detector/powered.json
+++ b/refinedstorage-common/src/main/resources/assets/refinedstorage/models/block/detector/powered.json
@@ -11,7 +11,7 @@
       ],
       "to": [
         9,
-        8,
+        7,
         9
       ],
       "shade": false,
@@ -19,45 +19,36 @@
         "north": {
           "uv": [
             7,
-            7,
+            8,
             9,
-            11
+            10
           ],
           "texture": "#side"
         },
         "east": {
           "uv": [
             7,
-            7,
+            8,
             9,
-            11
+            10
           ],
           "texture": "#side"
         },
         "south": {
           "uv": [
             7,
-            7,
+            8,
             9,
-            11
+            10
           ],
           "texture": "#side"
         },
         "west": {
           "uv": [
             7,
-            7,
+            8,
             9,
-            11
-          ],
-          "texture": "#side"
-        },
-        "up": {
-          "uv": [
-            7,
-            7,
-            9,
-            9
+            10
           ],
           "texture": "#side"
         }
@@ -151,7 +142,7 @@
             6,
             4,
             10,
-            12
+            10
           ],
           "texture": "#torch",
           "neoforge_data": {
@@ -164,7 +155,7 @@
             6,
             4,
             10,
-            12
+            10
           ],
           "texture": "#torch",
           "neoforge_data": {
@@ -193,7 +184,7 @@
             6,
             4,
             10,
-            12
+            10
           ],
           "texture": "#torch",
           "neoforge_data": {
@@ -206,7 +197,36 @@
             6,
             4,
             10,
-            12
+            10
+          ],
+          "texture": "#torch",
+          "neoforge_data": {
+            "block_light": 15,
+            "sky_light": 15
+          }
+        }
+      }
+    },
+    {
+      "name": "Torch",
+      "from": [
+        7,
+        10,
+        7
+      ],
+      "to": [
+        9,
+        10,
+        9
+      ],
+      "shade": false,
+      "faces": {
+        "up": {
+          "uv": [
+            7,
+            5,
+            9,
+            7
           ],
           "texture": "#torch",
           "neoforge_data": {

--- a/refinedstorage-common/src/main/resources/assets/refinedstorage/models/block/detector/unpowered.json
+++ b/refinedstorage-common/src/main/resources/assets/refinedstorage/models/block/detector/unpowered.json
@@ -28,7 +28,7 @@
             7,
             7,
             9,
-            11
+            10
           ],
           "texture": "#side"
         },
@@ -37,7 +37,7 @@
             7,
             7,
             9,
-            11
+            10
           ],
           "texture": "#side"
         },
@@ -46,7 +46,7 @@
             7,
             7,
             9,
-            11
+            10
           ],
           "texture": "#side"
         },
@@ -55,16 +55,7 @@
             7,
             7,
             9,
-            11
-          ],
-          "texture": "#side"
-        },
-        "up": {
-          "uv": [
-            7,
-            7,
-            9,
-            9
+            10
           ],
           "texture": "#side"
         }
@@ -143,31 +134,31 @@
       "name": "Torch",
       "from": [
         7,
-        5,
-        6
+        8,
+        7
       ],
       "to": [
         9,
-        11,
-        10
+        10,
+        9
       ],
       "shade": false,
       "faces": {
         "east": {
           "uv": [
-            6,
-            4,
-            10,
-            12
+            7,
+            5,
+            9,
+            7
           ],
           "texture": "#torch"
         },
         "west": {
           "uv": [
-            6,
-            4,
-            10,
-            12
+            7,
+            5,
+            9,
+            7
           ],
           "texture": "#torch"
         }
@@ -176,34 +167,63 @@
     {
       "name": "Torch",
       "from": [
-        6,
-        5,
+        7,
+        8,
         7
       ],
       "to": [
+        9,
         10,
-        11,
         9
       ],
       "shade": false,
       "faces": {
         "north": {
           "uv": [
-            6,
-            4,
-            10,
-            12
+            7,
+            5,
+            9,
+            7
           ],
           "texture": "#torch"
         },
         "south": {
           "uv": [
-            6,
-            4,
-            10,
-            12
+            7,
+            5,
+            9,
+            7
           ],
           "texture": "#torch"
+        }
+      }
+    },
+    {
+      "name": "Torch",
+      "from": [
+        7,
+        10,
+        7
+      ],
+      "to": [
+        9,
+        10,
+        9
+      ],
+      "shade": false,
+      "faces": {
+        "up": {
+          "uv": [
+            7,
+            5,
+            9,
+            7
+          ],
+          "texture": "#torch",
+          "neoforge_data": {
+            "block_light": 15,
+            "sky_light": 15
+          }
         }
       }
     }


### PR DESCRIPTION
A top face is added to the model and the model's uv coordinates are modified to match the vanilla redstone torch.