### PR TITLE
fix: searching checks both item name and display name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+-   Searching in the Grid now checks against the resource name, registry id, and display name (for renamed items)
+
 ## [3.0.0-beta.4] - 2026-04-16
 
 ### Added

--- a/refinedstorage-common-api/src/main/java/com/refinedmods/refinedstorage/common/api/grid/view/AbstractGridResource.java
+++ b/refinedstorage-common-api/src/main/java/com/refinedmods/refinedstorage/common/api/grid/view/AbstractGridResource.java
@@ -5,6 +5,7 @@ import com.refinedmods.refinedstorage.api.resource.repository.ResourceRepository
 import com.refinedmods.refinedstorage.api.storage.tracked.TrackedResource;
 import com.refinedmods.refinedstorage.common.api.support.resource.PlatformResourceKey;
 
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -14,14 +15,14 @@ import org.jspecify.annotations.Nullable;
 @API(status = API.Status.STABLE, since = "2.0.0-milestone.3.0")
 public abstract class AbstractGridResource<T extends PlatformResourceKey> implements GridResource {
     protected final T resource;
-    private final String name;
+    private final List<String> names;
     private final Function<GridResourceAttributeKey, Set<String>> attributes;
 
     protected AbstractGridResource(final T resource,
-                                   final String name,
+                                   final List<String> names,
                                    final Function<GridResourceAttributeKey, Set<String>> attributes) {
         this.resource = resource;
-        this.name = name;
+        this.names = names;
         this.attributes = attributes;
     }
 
@@ -39,8 +40,13 @@ public abstract class AbstractGridResource<T extends PlatformResourceKey> implem
     }
 
     @Override
-    public String getName() {
-        return name;
+    public List<String> getSearchableNames() {
+        return names;
+    }
+
+    @Override
+    public String getHoverName() {
+        return names.getLast();
     }
 
     @Override
@@ -63,7 +69,7 @@ public abstract class AbstractGridResource<T extends PlatformResourceKey> implem
     public String toString() {
         return "AbstractGridResource{"
             + "resource=" + resource
-            + ", name='" + name + '\''
+            + ", valid names='" + getSearchableNames() + '\''
             + ", attributes=" + attributes
             + '}';
     }

--- a/refinedstorage-common-api/src/main/java/com/refinedmods/refinedstorage/common/api/grid/view/GridResource.java
+++ b/refinedstorage-common-api/src/main/java/com/refinedmods/refinedstorage/common/api/grid/view/GridResource.java
@@ -31,7 +31,9 @@ public interface GridResource {
 
     long getAmount(ResourceRepository<GridResource> repository);
 
-    String getName();
+    List<String> getSearchableNames();
+
+    String getHoverName();
 
     Set<String> getAttribute(GridResourceAttributeKey key);
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/GridSortingTypes.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/GridSortingTypes.java
@@ -11,7 +11,7 @@ import org.jspecify.annotations.Nullable;
 
 public enum GridSortingTypes {
     QUANTITY(trp -> view -> Comparator.comparingLong(value -> value.getAmount(view))),
-    NAME(trp -> view -> Comparator.comparing(GridResource::getName)),
+    NAME(trp -> view -> Comparator.comparing(GridResource::getHoverName)),
     ID(trp -> view -> Comparator.comparingInt(GridResource::getRegistryId)),
     LAST_MODIFIED(trp -> view -> (a, b) -> {
         final long lastModifiedA = extractTime(trp.getTrackedResource(a));

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/query/GridQueryParser.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/query/GridQueryParser.java
@@ -178,7 +178,9 @@ public class GridQueryParser {
     }
 
     private static ResourceRepositoryFilter<GridResource> parseLiteral(final LiteralNode node) {
-        return (repository, resource) -> normalize(resource.getName()).contains(normalize(node.token().content()));
+        return (repository, resource) ->
+            resource.getSearchableNames().stream().anyMatch(name ->
+                normalize(name).contains(normalize(node.token().content())));
     }
 
     private static ResourceRepositoryFilter<GridResource> and(

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/AbstractItemGridResourceRepositoryMapper.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/AbstractItemGridResourceRepositoryMapper.java
@@ -34,6 +34,7 @@ public abstract class AbstractItemGridResourceRepositoryMapper implements Resour
         final ItemResource itemResource = (ItemResource) resource;
         final Item item = itemResource.item();
         final ItemStack itemStack = itemResource.toItemStack();
+        final String hoverName = itemStack.getHoverName().getString();
         final String name = item.getName(itemStack).getString();
         final String modId = getModId(itemStack);
         final String modName = getModName(modId).orElse("");
@@ -46,6 +47,7 @@ public abstract class AbstractItemGridResourceRepositoryMapper implements Resour
         return new ItemGridResource(
             itemResource,
             itemStack,
+            hoverName,
             name,
             k -> attributes.getOrDefault(k, Collections::emptySet).get()
         );

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/FluidGridResource.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/FluidGridResource.java
@@ -41,7 +41,9 @@ public class FluidGridResource extends AbstractGridResource<FluidResource> {
     public FluidGridResource(final FluidResource resource,
                              final String name,
                              final Function<GridResourceAttributeKey, Set<String>> attributes) {
-        super(resource, name, attributes);
+        super(resource,
+            List.of(BuiltInRegistries.FLUID.getKey(resource.fluid()).getPath(), name),
+            attributes);
         this.id = BuiltInRegistries.FLUID.getId(resource.fluid());
         this.rendering = RefinedStorageClientApi.INSTANCE.getResourceRendering(FluidResource.class);
     }

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/ItemGridResource.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/view/ItemGridResource.java
@@ -25,6 +25,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.inventory.tooltip.TooltipComponent;
 import net.minecraft.world.item.Item;
@@ -45,9 +46,12 @@ public class ItemGridResource extends AbstractGridResource<ItemResource> {
 
     public ItemGridResource(final ItemResource resource,
                             final ItemStack itemStack,
+                            final String hoverName,
                             final String name,
                             final Function<GridResourceAttributeKey, Set<String>> attributes) {
-        super(resource, name, attributes);
+        super(resource,
+            List.of(BuiltInRegistries.ITEM.getKey(resource.item()).getPath(), name, hoverName),
+            attributes);
         this.id = Item.getId(resource.item());
         this.itemStack = itemStack;
         this.itemResource = resource;

--- a/refinedstorage-common/src/test/java/com/refinedmods/refinedstorage/common/grid/GridSortingTypesTest.java
+++ b/refinedstorage-common/src/test/java/com/refinedmods/refinedstorage/common/grid/GridSortingTypesTest.java
@@ -51,7 +51,7 @@ class GridSortingTypesTest {
     void setUp() {
         builder = new ResourceRepositoryBuilderImpl<>(
             MAPPER,
-            view -> Comparator.comparing(GridResource::getName),
+            view -> Comparator.comparing(GridResource::getHoverName),
             view -> Comparator.comparingLong(resource -> resource.getAmount(view))
         );
         dirt = new ItemResource(Items.DIRT, DataComponentPatch.EMPTY);
@@ -85,28 +85,28 @@ class GridSortingTypesTest {
         // Assert
         switch (sortingType) {
             case QUANTITY -> assertThat(repository.getViewList())
-                .extracting(GridResource::getName)
+                .extracting(GridResource::getHoverName)
                 .containsExactly(
                     "Stone",
                     "Gold Ingot",
                     "Dirt"
                 );
             case NAME -> assertThat(repository.getViewList())
-                .extracting(GridResource::getName)
+                .extracting(GridResource::getHoverName)
                 .containsExactly(
                     "Dirt",
                     "Gold Ingot",
                     "Stone"
                 );
             case ID -> assertThat(repository.getViewList())
-                .extracting(GridResource::getName)
+                .extracting(resource -> resource.getSearchableNames().getLast())
                 .containsExactly(
                     "Stone",
                     "Dirt",
                     "Gold Ingot"
                 );
             case LAST_MODIFIED -> assertThat(repository.getViewList())
-                .extracting(GridResource::getName)
+                .extracting(GridResource::getHoverName)
                 .containsExactly(
                     "Gold Ingot",
                     "Stone",
@@ -142,28 +142,28 @@ class GridSortingTypesTest {
         // Assert
         switch (sortingType) {
             case QUANTITY -> assertThat(repository.getViewList())
-                .extracting(GridResource::getName)
+                .extracting(GridResource::getHoverName)
                 .containsExactly(
                     "Dirt",
                     "Gold Ingot",
                     "Stone"
                 );
             case NAME -> assertThat(repository.getViewList())
-                .extracting(GridResource::getName)
+                .extracting(GridResource::getHoverName)
                 .containsExactly(
                     "Stone",
                     "Gold Ingot",
                     "Dirt"
                 );
             case ID -> assertThat(repository.getViewList())
-                .extracting(GridResource::getName)
+                .extracting(GridResource::getHoverName)
                 .containsExactly(
                     "Gold Ingot",
                     "Dirt",
                     "Stone"
                 );
             case LAST_MODIFIED -> assertThat(repository.getViewList())
-                .extracting(GridResource::getName)
+                .extracting(GridResource::getHoverName)
                 .containsExactly(
                     "Dirt",
                     "Stone",

--- a/refinedstorage-common/src/test/java/com/refinedmods/refinedstorage/common/grid/query/GridQueryParserImplTest.java
+++ b/refinedstorage-common/src/test/java/com/refinedmods/refinedstorage/common/grid/query/GridQueryParserImplTest.java
@@ -52,7 +52,7 @@ class GridQueryParserImplTest {
         },
         MutableResourceListImpl.create(),
         new HashSet<>(),
-        v -> Comparator.comparing(GridResource::getName),
+        v -> Comparator.comparing(GridResource::getHoverName),
         v -> Comparator.comparingLong(resource -> resource.getAmount(v))
     );
 
@@ -68,13 +68,13 @@ class GridQueryParserImplTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"dirt", "Dirt", "DiRt", "Di", "irt"})
+    @ValueSource(strings = {"dirt", "Dirt", "DiRt", "Di", "irt", "test", "TeSt"})
     void testNameQuery(final String query) throws GridQueryParserException {
         // Act
         final var predicate = sut.parse(query);
 
         // Assert
-        assertThat(predicate.test(repository, new R("Dirt"))).isTrue();
+        assertThat(predicate.test(repository, new R(List.of("Dirt", "test")))).isTrue();
         assertThat(predicate.test(repository, new R("Glass"))).isFalse();
     }
 
@@ -287,18 +287,42 @@ class GridQueryParserImplTest {
     }
 
     private static class R implements GridResource {
-        private final String name;
+        private final List<String> names;
         private final long amount;
         private final Map<GridResourceAttributeKey, Set<String>> attributes;
 
+        R(final List<String> names) {
+            this(names, 1);
+        }
+
+        R(final List<String> names, final long amount) {
+            this.names = names;
+            this.amount = amount;
+            this.attributes = Map.of();
+        }
+
+        R(
+            final List<String> names,
+            final long amount,
+            final String modId,
+            final String modName,
+            final Set<String> tags
+        ) {
+            this.names = names;
+            this.amount = amount;
+            this.attributes = Map.of(
+                GridResourceAttributeKeys.MOD_ID, Set.of(modId),
+                GridResourceAttributeKeys.MOD_NAME, Set.of(modName),
+                GridResourceAttributeKeys.TAGS, tags
+            );
+        }
+
         R(final String name) {
-            this(name, 1);
+            this(List.of(name), 1);
         }
 
         R(final String name, final long amount) {
-            this.name = name;
-            this.amount = amount;
-            this.attributes = Map.of();
+            this(List.of(name), amount);
         }
 
         R(
@@ -308,13 +332,7 @@ class GridQueryParserImplTest {
             final String modName,
             final Set<String> tags
         ) {
-            this.name = name;
-            this.amount = amount;
-            this.attributes = Map.of(
-                GridResourceAttributeKeys.MOD_ID, Set.of(modId),
-                GridResourceAttributeKeys.MOD_NAME, Set.of(modName),
-                GridResourceAttributeKeys.TAGS, tags
-            );
+            this(List.of(name), amount, modId, modName, tags);
         }
 
         @Override
@@ -331,8 +349,13 @@ class GridQueryParserImplTest {
         }
 
         @Override
-        public String getName() {
-            return name;
+        public List<String> getSearchableNames() {
+            return names;
+        }
+
+        @Override
+        public String getHoverName() {
+            return getSearchableNames().getLast();
         }
 
         @Override


### PR DESCRIPTION
Added an itemName and a name variable to AbstractGridResource

If there is a stack of paper named "dinnerbone"
To get the item name "Paper" use resource.getItemName()
To get the display name "dinnerbone" use resource.getDisplayName()

GridQueryParser.parseLiteral() checks both itemName and displayName.