### PR TITLE
fix: output network must also listen to storage from input network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 -   Search box highlight marking text as invalid when the cursor is positioned within the text.
+-   Autocrafting tasks started from a subnetwork not completing when the processing output is imported into the main network, through a Relay that shares both autocrafting and storage.
 
 ## [3.0.5] - 2026-05-20
 

--- a/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/autocrafting/TaskContainer.java
+++ b/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/autocrafting/TaskContainer.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,11 +53,9 @@ public class TaskContainer {
         parents.add(parent);
     }
 
-    public void add(final Task task, @Nullable final Network network) {
+    public void add(final Task task, final List<StorageNetworkComponent> storages) {
         tasks.add(task);
-        if (network != null) {
-            attach(task, network.getComponent(StorageNetworkComponent.class));
-        }
+        storages.forEach(storage -> attach(task, storage));
     }
 
     public void cancel(final TaskId id) {
@@ -71,13 +68,11 @@ public class TaskContainer {
         throw new IllegalArgumentException("Task %s not found".formatted(id));
     }
 
-    public void attachAll(final Network network) {
-        final StorageNetworkComponent storage = network.getComponent(StorageNetworkComponent.class);
+    public void attachAll(final StorageNetworkComponent storage) {
         tasks.forEach(task -> attach(task, storage));
     }
 
-    public void detachAll(final Network network) {
-        final StorageNetworkComponent storage = network.getComponent(StorageNetworkComponent.class);
+    public void detachAll(final StorageNetworkComponent storage) {
         tasks.forEach(task -> detach(task, storage));
     }
 

--- a/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/node/patternprovider/PatternProviderNetworkNode.java
+++ b/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/node/patternprovider/PatternProviderNetworkNode.java
@@ -17,6 +17,7 @@ import com.refinedmods.refinedstorage.api.network.autocrafting.PatternProvider;
 import com.refinedmods.refinedstorage.api.network.autocrafting.PatternProviderExternalPatternSink;
 import com.refinedmods.refinedstorage.api.network.impl.autocrafting.TaskContainer;
 import com.refinedmods.refinedstorage.api.network.impl.node.SimpleNetworkNode;
+import com.refinedmods.refinedstorage.api.network.storage.StorageNetworkComponent;
 import com.refinedmods.refinedstorage.api.resource.ResourceAmount;
 import com.refinedmods.refinedstorage.api.resource.ResourceKey;
 
@@ -80,11 +81,11 @@ public class PatternProviderNetworkNode extends SimpleNetworkNode implements Pat
     @Override
     public void setNetwork(@Nullable final Network network) {
         if (this.network != null) {
-            tasks.detachAll(this.network);
+            tasks.detachAll(this.network.getComponent(StorageNetworkComponent.class));
         }
         super.setNetwork(network);
         if (network != null) {
-            tasks.attachAll(network);
+            tasks.attachAll(network.getComponent(StorageNetworkComponent.class));
         }
     }
 
@@ -130,7 +131,7 @@ public class PatternProviderNetworkNode extends SimpleNetworkNode implements Pat
 
     @Override
     public void addTask(final Task task) {
-        tasks.add(task, network);
+        tasks.add(task, network != null ? List.of(network.getComponent(StorageNetworkComponent.class)) : List.of());
         parents.forEach(parent -> parent.taskAdded(this, task));
     }
 

--- a/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/node/relay/RelayOutputNetworkNode.java
+++ b/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/node/relay/RelayOutputNetworkNode.java
@@ -60,6 +60,7 @@ public class RelayOutputNetworkNode extends AbstractNetworkNode
 
     void setStorageDelegate(@Nullable final StorageNetworkComponent storageDelegate) {
         this.storage.setDelegate(storageDelegate);
+        this.patternProvider.setStorageDelegate(storageDelegate);
     }
 
     void setAutocraftingDelegate(@Nullable final AutocraftingNetworkComponent autocraftingDelegate) {

--- a/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/node/relay/RelayOutputPatternProvider.java
+++ b/refinedstorage-network/src/main/java/com/refinedmods/refinedstorage/api/network/impl/node/relay/RelayOutputPatternProvider.java
@@ -16,11 +16,13 @@ import com.refinedmods.refinedstorage.api.network.autocrafting.ParentContainer;
 import com.refinedmods.refinedstorage.api.network.autocrafting.PatternListener;
 import com.refinedmods.refinedstorage.api.network.autocrafting.PatternProvider;
 import com.refinedmods.refinedstorage.api.network.impl.autocrafting.TaskContainer;
+import com.refinedmods.refinedstorage.api.network.storage.StorageNetworkComponent;
 import com.refinedmods.refinedstorage.api.resource.ResourceAmount;
 import com.refinedmods.refinedstorage.api.resource.ResourceKey;
 import com.refinedmods.refinedstorage.api.resource.filter.Filter;
 import com.refinedmods.refinedstorage.api.resource.filter.FilterMode;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -40,6 +42,8 @@ class RelayOutputPatternProvider implements PatternProvider, PatternListener, Ta
     private final TaskContainer tasks = new TaskContainer(this);
     @Nullable
     private AutocraftingNetworkComponent delegate;
+    @Nullable
+    private StorageNetworkComponent storageDelegate;
     private StepBehavior stepBehavior = StepBehavior.DEFAULT;
     @Nullable
     private ExternalPatternSinkId id;
@@ -83,6 +87,16 @@ class RelayOutputPatternProvider implements PatternProvider, PatternListener, Ta
         }
     }
 
+    public void setStorageDelegate(final @Nullable StorageNetworkComponent newDelegate) {
+        if (this.storageDelegate != null) {
+            tasks.detachAll(this.storageDelegate);
+        }
+        this.storageDelegate = newDelegate;
+        if (newDelegate != null) {
+            tasks.attachAll(newDelegate);
+        }
+    }
+
     boolean hasDelegate() {
         return delegate != null;
     }
@@ -121,7 +135,15 @@ class RelayOutputPatternProvider implements PatternProvider, PatternListener, Ta
 
     @Override
     public void addTask(final Task task) {
-        tasks.add(task, outputNode.getNetwork());
+        final List<StorageNetworkComponent> relevantStorages = new ArrayList<>();
+        final Network outputNetwork = outputNode.getNetwork();
+        if (outputNetwork != null) {
+            relevantStorages.add(outputNetwork.getComponent(StorageNetworkComponent.class));
+        }
+        if (storageDelegate != null) {
+            relevantStorages.add(storageDelegate);
+        }
+        tasks.add(task, relevantStorages);
         parents.forEach(parent -> parent.taskAdded(this, task));
     }
 
@@ -229,10 +251,10 @@ class RelayOutputPatternProvider implements PatternProvider, PatternListener, Ta
     }
 
     void detachAll(final Network network) {
-        tasks.detachAll(network);
+        tasks.detachAll(network.getComponent(StorageNetworkComponent.class));
     }
 
     void attachAll(final Network network) {
-        tasks.attachAll(network);
+        tasks.attachAll(network.getComponent(StorageNetworkComponent.class));
     }
 }

--- a/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/node/relay/RelayAutocraftingNetworkNodeTest.java
+++ b/refinedstorage-network/src/test/java/com/refinedmods/refinedstorage/api/network/impl/node/relay/RelayAutocraftingNetworkNodeTest.java
@@ -619,6 +619,47 @@ class RelayAutocraftingNetworkNodeTest {
         );
     }
 
+    @Test
+    void shouldDetectExternalPatternOutputDeliveredIntoMainNetworkStorage(
+        @InjectNetworkAutocraftingComponent(networkId = "input") final AutocraftingNetworkComponent inputAutocrafting,
+        @InjectNetworkAutocraftingComponent(networkId = "output") final AutocraftingNetworkComponent outputAutocrafting,
+        @InjectNetworkStorageComponent(networkId = "input") final StorageNetworkComponent inputStorage
+    ) {
+        // Arrange
+        input.setActive(true);
+        input.setOutputNode(output);
+        inputStorage.addSource(new StorageImpl());
+
+        final PatternProviderNetworkNode patternProvider = createPatternProvider();
+        patternProvider.tryUpdatePattern(0, pattern(PatternType.EXTERNAL)
+            .ingredient(A, 1)
+            .output(B, 1)
+            .build());
+        final PatternProviderExternalPatternSinkImpl sink = new PatternProviderExternalPatternSinkImpl();
+        patternProvider.setSink(sink);
+        inputAutocrafting.onContainerAdded(() -> patternProvider);
+
+        inputStorage.insert(A, 1, Action.EXECUTE, Actor.EMPTY);
+
+        input.setComponentTypes(Set.of(RelayComponentType.AUTOCRAFTING, RelayComponentType.STORAGE));
+
+        assertThat(outputAutocrafting.startTask(B, 1, Actor.EMPTY, false, CancellationToken.NONE)).isPresent();
+
+        output.doWork();
+        output.doWork();
+        assertThat(output.getTasks()).hasSize(1);
+        assertThat(sink.getAll()).usingRecursiveFieldByFieldElementComparator().containsExactly(
+            new ResourceAmount(A, 1)
+        );
+
+        // Act
+        inputStorage.insert(B, 1, Action.EXECUTE, Actor.EMPTY);
+        output.doWork();
+
+        // Assert
+        assertThat(output.getTasks()).isEmpty();
+    }
+
     @Nested
     @SetupNetwork(id = "output2")
     class NetworkChangeTest {


### PR DESCRIPTION
Otherwise, we cannot detect processing outputs if they run inside/are imported of as part of
the main network, but are started
from the subnetwork.

Fixes GH-1045
