### PR TITLE
perf: avoid repeated query normalization in Grid search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 -   Detector emitting an incorrect redstone signal for a brief moment on chunk load, because network storages weren't fully initialized yet. The Detector now only changes its redstone signal after the change has been stable for 1 second.
 -   Action buttons in amount screens going out of bounds in certain languages.
 -   "Craft" text in Grid going out of bounds in certain languages.
+-   Slow Grid searching on networks with many different resources.
 
 ## [3.2.1] - 2026-06-07
 

--- a/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/query/GridQueryParser.java
+++ b/refinedstorage-common/src/main/java/com/refinedmods/refinedstorage/common/grid/query/GridQueryParser.java
@@ -21,7 +21,6 @@ import com.refinedmods.refinedstorage.query.parser.node.UnaryOpNode;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -166,11 +165,17 @@ public class GridQueryParser {
         final Set<GridResourceAttributeKey> keys,
         final String query
     ) {
-        return (repository, resource) -> keys
-            .stream()
-            .map(resource::getAttribute)
-            .flatMap(Collection::stream)
-            .anyMatch(value -> normalize(value).contains(normalize(query)));
+        final String normalizedQuery = normalize(query);
+        return (repository, resource) -> {
+            for (final GridResourceAttributeKey key : keys) {
+                for (final String value : resource.getAttribute(key)) {
+                    if (normalize(value).contains(normalizedQuery)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        };
     }
 
     private static String normalize(final String value) {
@@ -178,9 +183,10 @@ public class GridQueryParser {
     }
 
     private static ResourceRepositoryFilter<GridResource> parseLiteral(final LiteralNode node) {
+        final String normalizedQuery = normalize(node.token().content());
         return (repository, resource) -> {
             for (final String name : resource.getSearchableNames()) {
-                if (normalize(name).contains(normalize(node.token().content()))) {
+                if (normalize(name).contains(normalizedQuery)) {
                     return true;
                 }
             }


### PR DESCRIPTION
Closes #1401

`GridQueryParser` normalized the search text inside the per resource lambda, and `attributeMatch` built a stream per resource, so a constant string was trimmed and lowercased once per resource per keystroke, on the render thread.

This moves the query normalization to where the filter is built and replaces the stream with nested loops. The resource side normalization is untouched, so results are identical. `count` already does its work at parse time, so this follows the existing shape.

Measured in a dev client on a network with 37,377 resources (a Creative Storage Disk filled with the debug stick, far beyond a normal network). Cost per keystroke, including the sort. Clearing the box runs the sort alone and costs 7.8 ms, so the filter is the part above that.

| query | before | after |
|---|---|---|
| `pickaxe` | 4.5 ms | 3.8 ms |
| `@minecraft` | 15.8 ms | 10.7 ms |
| `#tool` | 21.6 ms | 14.5 ms |

Attribute and tag searches gain the most, because there the per resource stream is removed as well as the normalization being hoisted. Row counts were identical on every key press, and the existing `GridQueryParserImplTest` tests pass unchanged.

<details>
<summary>How to reproduce the measurement</summary>

Build a network with a Disk Drive, a Grid and a Creative Storage Disk, then fill the disk using the debug stick while crouching. That gives roughly 37,000 resources.

Apply this to `AbstractGridContainerMenu` for a timing per key press in the log, then type `#tool` one character at a time with and without this PR. Both the parse and the filtering are inside the timer, because this change moves work from the filtering (once per resource) to the parse (once per keystroke), and timing only the filtering would hide that.

```diff
     private boolean onSearchTextChanged(final String text) {
         try {
-            repository.setFilterAndSort(andFilter(QUERY_PARSER.parse(text), createBaseFilter()));
+            final long start = System.nanoTime();
+            repository.setFilterAndSort(andFilter(QUERY_PARSER.parse(text), createBaseFilter()));
+            LOGGER.info("query={} rows={} ms={}", text,
+                repository.getViewList().size(), (System.nanoTime() - start) / 1000000.0);
             return true;
         } catch (GridQueryParserException e) {
             repository.setFilterAndSort((v, resource) -> false);
```

</details>
